### PR TITLE
25 add support for `pd.DataFrame` in CPI LOCO and PrmutationImportance

### DIFF
--- a/hidimstat/cpi.py
+++ b/hidimstat/cpi.py
@@ -167,7 +167,6 @@ class CPI(BaseEstimator):
                 X_perm = np.empty_like(X)
                 X_perm[:, non_group_ids] = X_minus_j
                 X_perm[:, group_ids] = X_j_perm
-
                 if isinstance(X, pd.DataFrame):
                     X_perm = pd.DataFrame(X_perm, columns=X.columns)
 

--- a/hidimstat/cpi.py
+++ b/hidimstat/cpi.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator, check_is_fitted, clone
 from sklearn.metrics import root_mean_squared_error
@@ -96,15 +97,19 @@ class CPI(BaseEstimator):
             Fit a single covariate estimator to predict a single group of
             covariates.
             """
-            X_j = X[:, self.groups[j]].copy()
-            X_minus_j = np.delete(X, self.groups[j], axis=1)
+            if isinstance(X, pd.DataFrame):
+                X_j = X[self.groups[j]].copy().values
+                X_minus_j = X.drop(columns=self.groups[j]).values
+            else:
+                X_j = X[:, self.groups[j]].copy()
+                X_minus_j = np.delete(X, self.groups[j], axis=1)
             estimator.fit(X_minus_j, X_j)
             return estimator
 
         # Parallelize the fitting of the covariate estimators
         self._list_imputation_models = Parallel(n_jobs=self.n_jobs)(
             delayed(_joblib_fit_one_group)(estimator, X, y, j)
-            for j, estimator in enumerate(self._list_imputation_models)
+            for j, estimator in zip(self.groups.keys(), self._list_imputation_models)
         )
 
         return self
@@ -139,19 +144,32 @@ class CPI(BaseEstimator):
             single group of covariates.
             """
             list_y_pred_perm = []
-            X_j = X[:, self.groups[j]].copy()
-            X_minus_j = np.delete(X, self.groups[j], axis=1)
+            if isinstance(X, pd.DataFrame):
+                X_j = X[self.groups[j]].copy().values
+                X_minus_j = X.drop(columns=self.groups[j]).values
+                group_ids = [
+                    i for i, col in enumerate(X.columns) if col in self.groups[j]
+                ]
+                non_group_ids = [
+                    i for i, col in enumerate(X.columns) if col not in self.groups[j]
+                ]
+            else:
+                X_j = X[:, self.groups[j]].copy()
+                X_minus_j = np.delete(X, self.groups[j], axis=1)
+                group_ids = self.groups[j]
+                non_group_ids = np.delete(np.arange(X.shape[1]), group_ids)
+
             X_j_hat = imputation_model.predict(X_minus_j).reshape(X_j.shape)
             residual_j = X_j - X_j_hat
-
-            group_ids = self.groups[j]
-            non_group_ids = np.delete(np.arange(X.shape[1]), group_ids)
 
             for _ in range(self.n_permutations):
                 X_j_perm = X_j_hat + self.rng.permutation(residual_j)
                 X_perm = np.empty_like(X)
                 X_perm[:, non_group_ids] = X_minus_j
                 X_perm[:, group_ids] = X_j_perm
+
+                if isinstance(X, pd.DataFrame):
+                    X_perm = pd.DataFrame(X_perm, columns=X.columns)
 
                 if self.score_proba:
                     y_pred_perm = self.estimator.predict_proba(X_perm)
@@ -164,7 +182,9 @@ class CPI(BaseEstimator):
         # Parallelize the computation of the importance scores for each group
         out_list = Parallel(n_jobs=self.n_jobs)(
             delayed(_joblib_predict_one_group)(imputation_model, X, j)
-            for j, imputation_model in enumerate(self._list_imputation_models)
+            for j, imputation_model in zip(
+                self.groups.keys(), self._list_imputation_models
+            )
         )
 
         residual_permuted_y_pred = np.stack(out_list, axis=0)

--- a/hidimstat/test/test_cpi.py
+++ b/hidimstat/test/test_cpi.py
@@ -44,8 +44,8 @@ def test_cpi(linear_scenario):
 
     # Same with groups and a pd.DataFrame
     groups = {
-        0: [f"col_{i}" for i in important_features],
-        1: [f"col_{i}" for i in non_important_features],
+        "group_0": [f"col_{i}" for i in important_features],
+        "the_group_1": [f"col_{i}" for i in non_important_features],
     }
     X_df = pd.DataFrame(X, columns=[f"col_{i}" for i in range(X.shape[1])])
     X_train_df, X_test_df, y_train, y_test = train_test_split(X_df, y, random_state=0)

--- a/hidimstat/test/test_loco.py
+++ b/hidimstat/test/test_loco.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 from sklearn.base import clone
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.metrics import log_loss
@@ -38,8 +39,14 @@ def test_loco(linear_scenario):
         > importance[non_important_features].mean()
     )
 
-    # Same with groups
-    groups = {0: important_features, 1: non_important_features}
+    # Same with groups and a pd.DataFrame
+    groups = {
+        "group_0": [f"col_{i}" for i in important_features],
+        "the_group_1": [f"col_{i}" for i in non_important_features],
+    }
+    X_df = pd.DataFrame(X, columns=[f"col_{i}" for i in range(X.shape[1])])
+    X_train_df, X_test_df, y_train, y_test = train_test_split(X_df, y, random_state=0)
+    regression_model.fit(X_train_df, y_train)
     loco = LOCO(
         estimator=regression_model,
         score_proba=False,
@@ -47,11 +54,11 @@ def test_loco(linear_scenario):
         n_jobs=1,
     )
     loco.fit(
-        X_train,
+        X_train_df,
         y_train,
         groups=groups,
     )
-    vim = loco.score(X_test, y_test)
+    vim = loco.score(X_test_df, y_test)
 
     importance = vim["importance"]
     assert importance[0].mean() > importance[1].mean()

--- a/hidimstat/test/test_permutation_importance.py
+++ b/hidimstat/test/test_permutation_importance.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.metrics import log_loss
 from sklearn.model_selection import train_test_split
@@ -38,8 +39,14 @@ def test_permutation_importance(linear_scenario):
         > importance[non_important_features].mean()
     )
 
-    # Same with groups
-    groups = {0: important_features, 1: non_important_features}
+    # Same with groups and a pd.DataFrame
+    groups = {
+        "group_0": [f"col_{i}" for i in important_features],
+        "the_group_1": [f"col_{i}" for i in non_important_features],
+    }
+    X_df = pd.DataFrame(X, columns=[f"col_{i}" for i in range(X.shape[1])])
+    X_train_df, X_test_df, y_train, y_test = train_test_split(X_df, y, random_state=0)
+    regression_model.fit(X_train_df, y_train)
     pi = PermutationImportance(
         estimator=regression_model,
         n_permutations=20,
@@ -48,11 +55,11 @@ def test_permutation_importance(linear_scenario):
         n_jobs=1,
     )
     pi.fit(
-        X_train,
+        X_train_df,
         y_train,
         groups=groups,
     )
-    vim = pi.score(X_test, y_test)
+    vim = pi.score(X_test_df, y_test)
 
     importance = vim["importance"]
     assert importance[0].mean() > importance[1].mean()


### PR DESCRIPTION
Motivation: Supporting `pd.DataFrames` can be convenient for variable importance inference since it allows the use of explicit variable / group of variable naming (eg a grouping dict of the format: 
```python
'mri': ['parcel_a', 'parcel_b' ...], 'fmri': ['connectivity_a', 'connectivity_b', ...])
```

This PR: Allow using `pd.DataFrames` as input in  in the `.fit`, `.predict` and `.score` methods of CPI, LOCO and PermutationImportance. The PR introduces minor changes including type checking in the above functions. 
It also adds the corresponding tests. 

