### PR TITLE
30 accelerate cpi by using batch prediction and numpy array operations instead of for loop

### DIFF
--- a/hidimstat/cpi.py
+++ b/hidimstat/cpi.py
@@ -169,18 +169,42 @@ class CPI(BaseEstimator):
             X_j_hat = imputation_model.predict(X_minus_j).reshape(X_j.shape)
             residual_j = X_j - X_j_hat
 
-            for _ in range(self.n_permutations):
-                X_j_perm = X_j_hat + self.rng.permutation(residual_j)
-                X_perm = np.empty_like(X)
-                X_perm[:, non_group_ids] = X_minus_j
-                X_perm[:, group_ids] = X_j_perm
-                if isinstance(X, pd.DataFrame):
-                    X_perm = pd.DataFrame(X_perm, columns=X.columns)
+            X_perm_all = np.empty((self.n_permutations, X.shape[0], X.shape[1]))
+            X_perm_all[:, :, non_group_ids] = X_minus_j
+            # n_permutations x n_samples x n_features_j
+            residual_j_perm = np.array(
+                [self.rng.permutation(residual_j) for _ in range(self.n_permutations)]
+            )
+            X_perm_all[:, :, group_ids] = X_j_hat[np.newaxis, :, :] + residual_j_perm
 
-                y_pred_perm = getattr(self.estimator, self.method)(X_perm)
-                list_y_pred_perm.append(y_pred_perm)
+            X_perm_batch = X_perm_all.reshape(-1, X.shape[1])
+            if isinstance(X, pd.DataFrame):
+                X_perm_batch = pd.DataFrame(
+                    X_perm_batch.reshape(-1, X.shape[1]), columns=X.columns
+                )
+            y_pred_perm = getattr(self.estimator, self.method)(X_perm_batch)
 
-            return np.array(list_y_pred_perm)
+            # In case of classification, the output is a 2D array. Reshape accordingly
+            if y_pred_perm.ndim == 1:
+                y_pred_perm = y_pred_perm.reshape(self.n_permutations, X.shape[0])
+            else:
+                y_pred_perm = y_pred_perm.reshape(
+                    self.n_permutations, X.shape[0], y_pred_perm.shape[1]
+                )
+            return y_pred_perm
+
+            # for _ in range(self.n_permutations):
+            #     X_j_perm = X_j_hat + self.rng.permutation(residual_j)
+            #     X_perm = np.empty_like(X)
+            #     X_perm[:, non_group_ids] = X_minus_j
+            #     X_perm[:, group_ids] = X_j_perm
+            #     if isinstance(X, pd.DataFrame):
+            #         X_perm = pd.DataFrame(X_perm, columns=X.columns)
+
+            #     y_pred_perm = getattr(self.estimator, self.method)(X_perm)
+            #     list_y_pred_perm.append(y_pred_perm)
+
+            # return np.array(list_y_pred_perm)
 
         # Parallelize the computation of the importance scores for each group
         out_list = Parallel(n_jobs=self.n_jobs)(


### PR DESCRIPTION
## Description 
New implementation of the method `CPI.predict`. The idea is to replace the for loop over permutation by a single batched prediction over all permuted arrays. 

N: number of samples
D: number of features
B: number of permutations 

### New
```
for p in range B:
   X_perm_j.append(sampling with jth group (conditionally) permuted)

X_perm_j  // shape P x N x D
y_pred_perm <- estimator.predict(X_perm_j )
```
### Previous
```
for p in range B:
   X_perm_j <- sampling with jth group (conditionally) permuted  // shape N x D
   y_pred_perm_p <- estimator.predict(X_perm_j )   // Shape N
```

## Results 
Using pytest benchmark I obtain very important computation time improvement. 

![image](https://github.com/user-attachments/assets/5a4d9599-ead9-40ee-b3f0-36f416578a9d)

## Reproducibility 
The above benchmark can be reproduced as follow: 
```bash
pip install pytest-benchmark
```
add the following test to the `test_cpi,py` file
```python
def test_benchmark(benchmark):

    rng = np.random.RandomState(0)
    X_train = rng.randn(80, 10)
    y_train = rng.randn(80)
    X_test = rng.randn(20, 10)
    print(y_train)

    regression_model = LinearRegression()
    regression_model.fit(X_train, y_train)
    imputation_model = LinearRegression()

    cpi = CPI(
        estimator=regression_model,
        imputation_model=imputation_model,
        n_permutations=20,
        method="predict",
        random_state=0,
        n_jobs=1,
    )
    cpi.fit(
        X_train,
        y_train,
        groups=None,
    )
    benchmark(cpi.predict, X_test)
    # Save the output to check reproducibility.
    # Make sure to comment the benchmark line above before as it
    # will change the rng state in an unpredictable way.
    # np.save("./.pytest_cache/y_pred_2.npy", cpi.predict(X_test))
```

Run the benchmark on the previous (main branch) implementation:
```bash
git checkout main
pytest hidimstat/test/test_cpi.py::test_benchmark --benchmark-json previous_implementation
```
Run the benchmark on the new implementation and compare restults:
```bash
git checkout 30-accelerate-cpi-by-using-batch-prediction-and-numpy-array-operations-instead-of-for-loop
pytest hidimstat/test/test_cpi.py::test_benchmark --benchmark-compare previous_implementation
```

### Consistency with previous implementation
The random seeding is done in a way that guarantees the exact consistency with the previous implementation.  