### PR TITLE
Remove the option y_fit of group_reid

### DIFF
--- a/test/test_noise_std.py
+++ b/test/test_noise_std.py
@@ -117,9 +117,6 @@ def test_group_reid():
     assert_almost_equal(np.max(error_ratio), 1.0, decimal=0)
     assert_almost_equal(np.log(np.min(error_ratio)), 0.0, decimal=1)
 
-    cov_hat, _ = group_reid(X, Y, fit_Y=False, stationary=False)
-    error_ratio = cov_hat / cov
-
     assert_almost_equal(np.max(error_ratio), 1.0, decimal=0)
     assert_almost_equal(np.log(np.min(error_ratio)), 0.0, decimal=0)
 


### PR DESCRIPTION
Following the issue #162, I propose to remove this option.