### PR TITLE
Fix CI failure by formatting examples. 

### DIFF
--- a/examples/plot_dcrt_example.py
+++ b/examples/plot_dcrt_example.py
@@ -12,10 +12,11 @@ the power
 # Imports needed for this script
 # ------------------------------
 
+import matplotlib.pyplot as plt
 import numpy as np
+
 from hidimstat.dcrt import dcrt_zero
 from hidimstat.scenario import multivariate_1D_simulation
-import matplotlib.pyplot as plt
 
 plt.rcParams.update({"font.size": 21})
 

--- a/examples/plot_diabetes_variable_importance_example.py
+++ b/examples/plot_diabetes_variable_importance_example.py
@@ -17,7 +17,7 @@ non-significant variables highly correlated with the significant ones and
 creating fake significant variables. They introduced a solution for the Random
 Forest estimator based on conditional sampling by performing sub-groups
 permutation when bisecting the space using the conditioning variables of the
-buiding process. However, this solution is exclusive to the Random Forest and 
+buiding process. However, this solution is exclusive to the Random Forest and
 is costly with high-dimensional settings.
 :footcite:t:`Chamma_NeurIPS2023` introduced a new model-agnostic solution to
 bypass the limitations of the permutation approach under the use of the

--- a/examples/plot_fmri_data_example.py
+++ b/examples/plot_fmri_data_example.py
@@ -57,8 +57,8 @@ from sklearn.utils import Bunch
 
 from hidimstat.adaptative_permutation_threshold_SVR import ada_svr
 from hidimstat.clustered_inference import clustered_inference
-from hidimstat.ensemble_clustered_inference import ensemble_clustered_inference
 from hidimstat.empirical_thresholding import empirical_thresholding
+from hidimstat.ensemble_clustered_inference import ensemble_clustered_inference
 from hidimstat.permutation_test import permutation_test, permutation_test_pval
 from hidimstat.stat_tools import pval_from_scale, zscore_from_pval
 

--- a/examples/plot_knockoff_aggregation.py
+++ b/examples/plot_knockoff_aggregation.py
@@ -22,13 +22,14 @@ References
 # Imports needed for this script
 # ------------------------------
 
-import numpy as np
-from hidimstat.data_simulation import simu_data
-from hidimstat.knockoffs import model_x_knockoff
-from hidimstat.knockoff_aggregation import knockoff_aggregation
-from hidimstat.utils import cal_fdp_power
-from sklearn.utils import check_random_state
 import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.utils import check_random_state
+
+from hidimstat.data_simulation import simu_data
+from hidimstat.knockoff_aggregation import knockoff_aggregation
+from hidimstat.knockoffs import model_x_knockoff
+from hidimstat.utils import cal_fdp_power
 
 plt.rcParams.update({"font.size": 26})
 

--- a/examples/plot_variable_importance_classif.py
+++ b/examples/plot_variable_importance_classif.py
@@ -2,15 +2,16 @@
 Measuring variable importance in classification
 ===============================================
 
-In this example, we illustrate how to measure variable importance in a classification 
-context. The problem under consideration is a binary classification where the target 
-variable is generated using a non-linear function of the features. Therefore 
-illustrating the importance of model-agnostic variable importance methods, which, as 
-opposed to linear models for instance, can capture non-linear relationships. 
-The features are generated from a multivariate normal distribution with a Toeplitz 
-correlation matrix. This second specificity of the problem is interesting to exemplify 
-the benefits of the conditional permutation importance (CPI) method [:footcite:t:`Chamma_NeurIPS2023`] 
-over the standard permutation importance (PI) method [:footcite:t:`breimanRandomForests2001`].
+In this example, we illustrate how to measure variable importance in a classification
+context. The problem under consideration is a binary classification where the target
+variable is generated using a non-linear function of the features. Therefore
+illustrating the importance of model-agnostic variable importance methods, which, as
+opposed to linear models for instance, can capture non-linear relationships. The
+features are generated from a multivariate normal distribution with a Toeplitz
+correlation matrix. This second specificity of the problem is interesting to exemplify
+the benefits of the conditional permutation importance (CPI) method
+[:footcite:t:`Chamma_NeurIPS2023`] over the standard permutation importance (PI) method
+[:footcite:t:`breimanRandomForests2001`].
 
 References
 ----------
@@ -45,7 +46,10 @@ from hidimstat import CPI, PermutationImportance
 # The BMI can be obtained by :math:`\text{BMI} = \frac{\text{weight}}{\text{height}^2}`.
 # And we simply mimic the weight and height variables by rescaling 2 correlated
 # features. The binary target is then generated using the formula:
-# :math:`y = \beta_1 \exp\left(\frac{|\text{bmi} - \text{mean(bmi)}|}{\text{std(bmi)}}\right) + \beta_2 \exp\left(|\text{weight}| \times 1\left[|\text{weight} - \text{mean(weight)}| > \text{quantile(weight, 0.80)}\right] \right) + \beta_3 \cdot \text{age} + \epsilon` where :math:`\epsilon`` is a Gaussian noise.
+# :math:`y = \beta_1 \exp\left(\frac{|\text{bmi} - \text{mean(bmi)}|}{\text{std(bmi)}}
+# \right) + \beta_2 \exp\left(|\text{weight}| \times 1\left[|\text{weight} -
+# \text{mean(weight)}| > \text{quantile(weight, 0.80)}\right] \right) + \beta_3 \cdot
+# \text{age} + \epsilon` where :math:`\epsilon`` is a Gaussian noise.
 # The first and second term are non-linear functions of the features, corresponding to
 # deviations from the population mean while the third term is a linear function of a
 # feature.
@@ -224,10 +228,10 @@ for j in range(n_features):
 # the true important features, used to generate the target variable, with a star marker.
 # While the linear model captures the importance of the age, it fails to capture the
 # importance of the weight and height because of its lack of expressivity. Using a
-# polynomial kernel, the non-linear model captures the importance of the weight and height.
-# Finally, the CPI method controls for false positive discoveries contrarily to the PI method
-# which identifies spurious important features simply because of the correlation structure of
-# the features.
+# polynomial kernel, the non-linear model captures the importance of the weight and
+# height. Finally, the CPI method controls for false positive discoveries contrarily
+# to the PI method which identifies spurious important features simply because of the
+# correlation structure of the features.
 
 fig, ax = plt.subplots()
 box1 = ax.boxplot(


### PR DESCRIPTION
 - Make sure that Python files do not contain trailing spaces
 - Enforce max number of characters per line for docstrings and comments
 - Sort imports