### PR TITLE
Rename `score` to `importance` in CPI, LOCO and PFI

### DIFF
--- a/examples/plot_diabetes_variable_importance_example.py
+++ b/examples/plot_diabetes_variable_importance_example.py
@@ -126,7 +126,7 @@ for i, (train_index, test_index) in enumerate(kf.split(X)):
         n_jobs=4,
     )
     cpi.fit(X_train, y_train)
-    importance = cpi.score(X_test, y_test)
+    importance = cpi.importance(X_test, y_test)
     cpi_importance_list.append(importance)
 
 #############################################################################
@@ -144,7 +144,7 @@ for i, (train_index, test_index) in enumerate(kf.split(X)):
         n_jobs=4,
     )
     loco.fit(X_train, y_train)
-    importance = loco.score(X_test, y_test)
+    importance = loco.importance(X_test, y_test)
     loco_importance_list.append(importance)
 
 
@@ -165,7 +165,7 @@ for i, (train_index, test_index) in enumerate(kf.split(X)):
         n_jobs=4,
     )
     pi.fit(X_train, y_train)
-    importance = pi.score(X_test, y_test)
+    importance = pi.importance(X_test, y_test)
     pi_importance_list.append(importance)
 
 

--- a/examples/plot_variable_importance_classif.py
+++ b/examples/plot_variable_importance_classif.py
@@ -172,7 +172,7 @@ for train, test in cv.split(X, y):
         method="decision_function",
     )
     cpi_linear.fit(X[train], y[train])
-    imp_cpi_linear = cpi_linear.score(X[test], y[test])["importance"]
+    imp_cpi_linear = cpi_linear.importance(X[test], y[test])["importance"]
 
     model_non_linear_c = clone(model_non_linear)
     model_non_linear_c.fit(X[train], y[train])
@@ -186,7 +186,7 @@ for train, test in cv.split(X, y):
         method="decision_function",
     )
     cpi_non_linear.fit(X[train], y[train])
-    imp_cpi_non_linear = cpi_non_linear.score(X[test], y[test])["importance"]
+    imp_cpi_non_linear = cpi_non_linear.importance(X[test], y[test])["importance"]
 
     pi_non_linear = PermutationImportance(
         estimator=model_non_linear_c,
@@ -196,7 +196,7 @@ for train, test in cv.split(X, y):
         method="decision_function",
     )
     pi_non_linear.fit(X[train], y[train])
-    imp_pi_non_linear = pi_non_linear.score(X[test], y[test])["importance"]
+    imp_pi_non_linear = pi_non_linear.importance(X[test], y[test])["importance"]
 
     importance_list.append(
         np.stack(

--- a/src/hidimstat/base_perturbation.py
+++ b/src/hidimstat/base_perturbation.py
@@ -108,7 +108,7 @@ class BasePerturbation(BaseEstimator):
         )
         return np.stack(out_list, axis=0)
 
-    def score(self, X, y):
+    def importance(self, X, y):
         """
         Compute the importance scores for each group of covariates.
 

--- a/test/test_cpi.py
+++ b/test/test_cpi.py
@@ -37,7 +37,7 @@ def test_cpi(linear_scenario):
         groups=None,
         var_type="auto",
     )
-    vim = cpi.score(X_test, y_test)
+    vim = cpi.importance(X_test, y_test)
 
     importance = vim["importance"]
     assert importance.shape == (X.shape[1],)
@@ -67,7 +67,7 @@ def test_cpi(linear_scenario):
         groups=groups,
         var_type="continuous",
     )
-    vim = cpi.score(X_test_df, y_test)
+    vim = cpi.importance(X_test_df, y_test)
 
     importance = vim["importance"]
     assert importance[0].mean() > importance[1].mean()
@@ -93,7 +93,7 @@ def test_cpi(linear_scenario):
         groups=None,
         var_type=["continuous"] * X.shape[1],
     )
-    vim = cpi.score(X_test, y_test_clf)
+    vim = cpi.importance(X_test, y_test_clf)
 
 
 def test_raises_value_error(
@@ -119,7 +119,7 @@ def test_raises_value_error(
             method="predict",
         )
 
-    # Not fitted imputation model with predict and score methods
+    # Not fitted imputation model with predict and importance methods
     with pytest.raises(ValueError):
         fitted_model = LinearRegression().fit(X, y)
         cpi = CPI(
@@ -133,4 +133,4 @@ def test_raises_value_error(
             estimator=fitted_model,
             method="predict",
         )
-        cpi.score(X, y)
+        cpi.importance(X, y)

--- a/test/test_loco.py
+++ b/test/test_loco.py
@@ -31,7 +31,7 @@ def test_loco(linear_scenario):
         y_train,
         groups=None,
     )
-    vim = loco.score(X_test, y_test)
+    vim = loco.importance(X_test, y_test)
 
     importance = vim["importance"]
     assert importance.shape == (X.shape[1],)
@@ -58,7 +58,7 @@ def test_loco(linear_scenario):
         y_train,
         groups=groups,
     )
-    vim = loco.score(X_test_df, y_test)
+    vim = loco.importance(X_test_df, y_test)
 
     importance = vim["importance"]
     assert importance[0].mean() > importance[1].mean()
@@ -80,7 +80,7 @@ def test_loco(linear_scenario):
         y_train_clf,
         groups=None,
     )
-    vim_clf = loco_clf.score(X_test, y_test_clf)
+    vim_clf = loco_clf.importance(X_test, y_test_clf)
 
     importance_clf = vim_clf["importance"]
     assert importance_clf.shape == (X.shape[1],)
@@ -98,7 +98,7 @@ def test_raises_value_error(
             method="predict",
         )
 
-    # Not fitted sub-model when calling score and predict
+    # Not fitted sub-model when calling importance and predict
     with pytest.raises(ValueError):
         fitted_model = LinearRegression().fit(X, y)
         loco = LOCO(
@@ -112,4 +112,4 @@ def test_raises_value_error(
             estimator=fitted_model,
             method="predict",
         )
-        loco.score(X, y)
+        loco.importance(X, y)

--- a/test/test_permutation_importance.py
+++ b/test/test_permutation_importance.py
@@ -31,7 +31,7 @@ def test_permutation_importance(linear_scenario):
         y_train,
         groups=None,
     )
-    vim = pi.score(X_test, y_test)
+    vim = pi.importance(X_test, y_test)
 
     importance = vim["importance"]
     assert importance.shape == (X.shape[1],)
@@ -60,7 +60,7 @@ def test_permutation_importance(linear_scenario):
         y_train,
         groups=groups,
     )
-    vim = pi.score(X_test_df, y_test)
+    vim = pi.importance(X_test_df, y_test)
 
     importance = vim["importance"]
     assert importance[0].mean() > importance[1].mean()
@@ -85,7 +85,7 @@ def test_permutation_importance(linear_scenario):
         y_train_clf,
         groups=None,
     )
-    vim_clf = pi_clf.score(X_test, y_test_clf)
+    vim_clf = pi_clf.importance(X_test, y_test_clf)
 
     importance_clf = vim_clf["importance"]
     assert importance_clf.shape == (X.shape[1],)


### PR DESCRIPTION
I changed the name of the `score` method to `importance` in the API, the tests, and the examples. Could you let me know if I missed something? 
Related to #201 #217