### PR TITLE
Update the option for the documentation for failing with warning

### DIFF
--- a/doc_conf/Makefile
+++ b/doc_conf/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W --keep-going -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/doc_conf/Makefile
+++ b/doc_conf/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W --keep-going -n
+SPHINXOPTS    = -W -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/doc_conf/api.rst
+++ b/doc_conf/api.rst
@@ -16,7 +16,6 @@ Functions
    :toctree: generated/
    :template: function.rst
 
-   aggregate_quantiles
    quantile_aggregation
    clustered_inference
    dcrt_zero

--- a/src/hidimstat/__init__.py
+++ b/src/hidimstat/__init__.py
@@ -27,7 +27,6 @@ except ImportError:
     __version__ = "0.0.0+unknown"
 
 __all__ = [
-    "aggregate_quantiles",
     "quantile_aggregation",
     "clustered_inference",
     "dcrt_zero",


### PR DESCRIPTION
The option:
-W is for falling at the end is there was a warning
-n is for checking the missing reference