### PR TITLE
fix compatibility with the nilearn 0.12

### DIFF
--- a/examples/plot_fmri_data_example.py
+++ b/examples/plot_fmri_data_example.py
@@ -273,12 +273,14 @@ def plot_map(
 if pval_dl is not None:
     plot_map(
         zscore_from_pval(pval_dl, one_minus_pval_dl),
-        zscore_threshold_no_clust,
+        float(zscore_threshold_no_clust),
         "Desparsified Lasso",
     )
 
 plot_map(
-    zscore_from_pval(pval_cdl, one_minus_pval_cdl), zscore_threshold_clust, "CluDL"
+    zscore_from_pval(pval_cdl, one_minus_pval_cdl),
+    float(zscore_threshold_clust),
+    "CluDL",
 )
 
 plot_map(selected, 0.5, "EnCluDL", vmin=-1, vmax=1)


### PR DESCRIPTION
The example of plot fmri uses an array of 1 element, as a threshold which is not supported by nilearn 0.12.

