### PR TITLE
Replace `n_alphas` by `alphas` for sklearn compatibility

### DIFF
--- a/src/hidimstat/distilled_conditional_randomization_test.py
+++ b/src/hidimstat/distilled_conditional_randomization_test.py
@@ -1,15 +1,16 @@
-import numpy as np
 import warnings
+
+import numpy as np
 from joblib import Parallel, delayed
 from scipy import stats
 from sklearn.base import clone
 from sklearn.linear_model import Lasso, LassoCV
 from sklearn.preprocessing import StandardScaler
 
-from hidimstat._utils.regression import _alpha_max
 from hidimstat._utils.docstring import _aggregate_docstring
-from hidimstat.base_variable_importance import BaseVariableImportance
+from hidimstat._utils.regression import _alpha_max
 from hidimstat._utils.utils import _check_vim_predict_method
+from hidimstat.base_variable_importance import BaseVariableImportance
 
 
 class D0CRT(BaseVariableImportance):
@@ -39,8 +40,7 @@ class D0CRT(BaseVariableImportance):
     params_lasso_screening : dict
         Parameters for variable screening Lasso:
         - alpha : float or None - L1 regularization strength. If None, determined by CV.
-        - n_alphas : int - Number of alphas for cross-validation (default: 10).
-        - alphas : array-like or None - List of alpha values to try in CV (default: None).
+        - alphas : array-like or None - List of alpha values to try in CV (default: 10).
         - alpha_max_fraction : float - Scale factor for alpha_max (default: 0.5).
         - cv : int - Cross-validation folds (default: 5).
         - tol : float - Convergence tolerance (default: 1e-6).
@@ -111,8 +111,7 @@ class D0CRT(BaseVariableImportance):
         sigma_X=None,
         params_lasso_screening={
             "alpha": None,
-            "n_alphas": 10,
-            "alphas": None,
+            "alphas": 10,
             "alpha_max_fraction": 0.5,
             "cv": 5,
             "tol": 1e-6,
@@ -449,8 +448,7 @@ def _joblib_fit(
         "n_jobs": 1,
         "random_state": 44,
         "alpha": None,
-        "n_alphas": 10,
-        "alphas": None,
+        "alphas": 10,
         "alpha_max_fraction": 0.5,
     },
 ):
@@ -616,7 +614,6 @@ def _fit_lasso(
     n_jobs,
     alpha,
     alphas,
-    n_alphas,
     alpha_max_fraction,
     **params,
 ):
@@ -632,15 +629,13 @@ def _fit_lasso(
     n_jobs : int
         Number of CPUs to use for cross-validation.
     alpha : float or None
-        Regularization strength. If None and alphas/n_alphas not provided,
+        Regularization strength. If None and alphas not provided,
         alpha is set to alpha_max_fraction * alpha_max.
     alphas : array-like or None
-        List of alphas to use for model fitting. If None and n_alphas > 0,
+        List of alphas to use for model fitting. If None,
         alphas are set automatically.
-    n_alphas : int
-        Number of alphas along the regularization path. Ignored if alphas is provided.
     alpha_max_fraction : float
-        Fraction of alpha_max to use when alpha, alphas, and n_alphas are not provided.
+        Fraction of alpha_max to use when alpha, and alphas are not provided.
     random_state : int, RandomState instance or None
         Random seed for reproducibility.
     **params : dict
@@ -653,12 +648,11 @@ def _fit_lasso(
 
     Notes
     -----
-    Uses cross-validation to select the best alpha if alphas or n_alphas are provided.
+    Uses cross-validation to select the best alpha if alphas are provided.
     Otherwise, uses a single alpha value either provided or computed from alpha_max_fraction.
     """
-    if alphas is not None or n_alphas > 0:
+    if alphas is not None:
         clf = LassoCV(
-            n_alphas=n_alphas,
             alphas=alphas,
             n_jobs=n_jobs,
             **params,
@@ -685,8 +679,7 @@ def d0crt(
     sigma_X=None,
     params_lasso_screening={
         "alpha": None,
-        "n_alphas": 10,
-        "alphas": None,
+        "alphas": 10,
         "alpha_max_fraction": 0.5,
         "cv": 5,
         "tol": 1e-6,

--- a/src/hidimstat/knockoffs.py
+++ b/src/hidimstat/knockoffs.py
@@ -11,11 +11,11 @@ from hidimstat.gaussian_knockoff import (
     gaussian_knockoff_generation,
     repeat_gaussian_knockoff_generation,
 )
-from hidimstat.statistical_tools.multiple_testing import fdr_threshold
 from hidimstat.statistical_tools.aggregation import quantile_aggregation
+from hidimstat.statistical_tools.multiple_testing import fdr_threshold
 
 
-def preconfigure_estimator_LassoCV(estimator, X, X_tilde, y, n_alphas=20):
+def preconfigure_estimator_LassoCV(estimator, X, X_tilde, y, alphas=20):
     """
     Configure the estimator for Model-X knockoffs.
 
@@ -38,7 +38,7 @@ def preconfigure_estimator_LassoCV(estimator, X, X_tilde, y, n_alphas=20):
     y : 1D ndarray (n_samples, )
         The target vector.
 
-    n_alphas : int, default=10
+    alphas : int, default=10
         The number of alpha values to use to instantiate the cross-validation.
 
     Returns
@@ -62,8 +62,8 @@ def preconfigure_estimator_LassoCV(estimator, X, X_tilde, y, n_alphas=20):
     n_features = X.shape[1]
     X_ko = np.column_stack([X, X_tilde])
     alpha_max = np.max(np.dot(X_ko.T, y)) / (2 * n_features)
-    alphas = np.linspace(alpha_max * np.exp(-n_alphas), alpha_max, n_alphas)
-    estimator.alphas = alphas
+
+    estimator.alphas = np.linspace(alpha_max * np.exp(-alphas), alpha_max, alphas)
     return estimator
 
 

--- a/test/test_distilled_conditional_randomization_test.py
+++ b/test/test_distilled_conditional_randomization_test.py
@@ -2,16 +2,15 @@
 Test the dcrt module
 """
 
-import pytest
 import numpy as np
+import pytest
 from sklearn.covariance import LedoitWolf
-from sklearn.datasets import make_regression, make_classification
-from sklearn.model_selection import KFold
-from sklearn.linear_model import LassoCV, Lasso
+from sklearn.datasets import make_classification, make_regression
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.linear_model import Lasso, LassoCV
+from sklearn.model_selection import KFold
 
-
-from hidimstat import d0crt, D0CRT
+from hidimstat import D0CRT, d0crt
 from hidimstat._utils.regression import _alpha_max
 
 
@@ -113,7 +112,6 @@ def test_dcrt_lasso_with_no_cv(generate_regation_dataset):
         estimator=LassoCV(n_jobs=1),
         params_lasso_screening={
             "alpha": None,
-            "n_alphas": 0,
             "alphas": None,
             "alpha_max_fraction": 0.5,
             "fit_intercept": False,
@@ -233,7 +231,6 @@ def test_dcrt_distillation_y_different():
         random_state=2024,
         params_lasso_distillation_x={
             "alpha": None,
-            "n_alphas": 0,
             "alphas": None,
             "alpha_max_fraction": 0.5,
             "fit_intercept": False,
@@ -258,7 +255,6 @@ def test_dcrt_lasso_fit_with_no_cv():
         fit_y=True,
         params_lasso_screening={
             "alpha": None,
-            "n_alphas": 0,
             "alphas": None,
             "alpha_max_fraction": 0.5,
             "fit_intercept": False,


### PR DESCRIPTION
This should remove the warning:
> warnings.warn(
/home/circleci/project/.venv/lib/python3.13/site-packages/sklearn/linear_model/_coordinate_descent.py:1622: FutureWarning: 'n_alphas' was deprecated in 1.7 and will be removed in 1.9. 'alphas' now accepts an integer value which removes the need to pass 'n_alphas'. The default value of 'alphas' will change from None to 100 in 1.9. Pass an explicit value to 'alphas' and leave 'n_alphas' to its default value to silence this warning.

