### PR TITLE
Update maximal version for scikitlearn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "joblib       >= 1.2.0, < 2",
     "numpy        >= 1.25,  < 3",
     "pandas       >= 2.2,   < 3",
-    "scikit-learn >= 1.5,   < 2",
+    "scikit-learn >= 1.5,   < 1.9",
     "scipy        >= 1.6,   < 2",
 ]
 requires-python = ">=3.9,   < 4"
@@ -47,14 +47,8 @@ doc = [
     "sphinx-prompt          >= 1.8.0,   < 2",
     "tqdm                   >= 4.1.0,   < 5",
 ]
-example = [
-    "matplotlib >= 3.1.0,   < 4",
-    "seaborn    >= 0.9,     < 1"
-    ]
-style = [
-    "black  >= 24.4.2",
-    "isort  >= 5.13.2"
-    ]
+example = ["matplotlib >= 3.1.0,   < 4", "seaborn    >= 0.9,     < 1"]
+style = ["black  >= 24.4.2", "isort  >= 5.13.2"]
 
 # For running unit and docstring tests
 test = [


### PR DESCRIPTION
As the remark of @jpaillard in PR #342, the `n_alphas` will be depreciate in the version 1.9 of scikitlearn.

'n_alphas' was deprecated in 1.7 and will be removed in 1.9. i 'alphas' now accepts an integer value which removes the need to pass 'n_alphas'. The default value of 'alphas' will change from i None to 100 in 1.9.