### PR TITLE
[DOC] use consistent divider and header length

### DIFF
--- a/examples/plot_2D_simulation_example.py
+++ b/examples/plot_2D_simulation_example.py
@@ -48,7 +48,7 @@ References
 """
 import matplotlib.pyplot as plt
 
-#############################################################################
+# %%
 # Imports needed for this script
 # ------------------------------
 import numpy as np
@@ -71,7 +71,7 @@ from hidimstat.ensemble_clustered_inference import (
 from hidimstat.statistical_tools.p_values import zscore_from_pval
 from hidimstat._utils.scenario import multivariate_simulation_spatial
 
-#############################################################################
+# %%
 # Specific plotting functions
 # ---------------------------
 # The functions below are used to plot the results and illustrate the concept
@@ -112,7 +112,7 @@ def weight_map_2D_extended(shape, roi_size, delta):
     return beta_extended
 
 
-##############################################################################
+# %%
 # To generate a plot that exhibits the true support and the estimated
 # supports for every method, we define the two following functions:
 
@@ -154,7 +154,7 @@ def plot(maps, titles):
     plt.show()
 
 
-##############################################################################
+# %%
 # Generating the data
 # -------------------
 #
@@ -175,7 +175,7 @@ X_init, y, beta, epsilon = multivariate_simulation_spatial(
     n_samples, shape, roi_size, signal_noise_ratio, smooth_X, seed=1
 )
 
-##############################################################################
+# %%
 # Choosing inference parameters
 # -----------------------------
 #
@@ -204,7 +204,7 @@ delta = 6
 # computation parameter
 n_jobs = 1
 
-##############################################################################
+# %%
 # Computing z-score thresholds for support estimation
 # ---------------------------------------------------
 #
@@ -223,7 +223,7 @@ correction_cluster = 1.0 / n_clusters
 thr_c = zscore_from_pval((fwer_target / 2) * correction_cluster)
 thr_nc = zscore_from_pval((fwer_target / 2) * correction_no_cluster)
 
-#############################################################################
+# %%
 # Inference with several algorithms
 # ---------------------------------
 #
@@ -233,7 +233,7 @@ thr_nc = zscore_from_pval((fwer_target / 2) * correction_no_cluster)
 # compute true support with visible spatial tolerance
 beta_extended = weight_map_2D_extended(shape, roi_size, delta)
 
-#############################################################################
+# %%
 # Now, we compute the support estimated by a high-dimensional statistical
 # infernece method that does not leverage the data structure. This method
 # was introduced by Javanmard, A. et al. (2014), Zhang, C. H. et al. (2014)
@@ -256,7 +256,7 @@ selected_dl = np.logical_or(
     pval_corr < fwer_target / 2, one_minus_pval_corr < fwer_target / 2
 )
 
-#############################################################################
+# %%
 # Now, we compute the support estimated using a clustered inference algorithm
 # (c.f. :footcite:t:`chevalier2022spatially`) called Clustered Desparsified Lasso
 # (CluDL) since it uses the Desparsified Lasso technique after clustering the data.
@@ -285,7 +285,7 @@ selected_cdl = np.logical_or(
     pval_corr < fwer_target / 2, one_minus_pval_corr < fwer_target / 2
 )
 
-#############################################################################
+# %%
 # Finally, we compute the support estimated by an ensembled clustered
 # inference algorithm (c.f. :footcite:t:`chevalier2022spatially`). This algorithm is called
 # Ensemble of Clustered Desparsified Lasso (EnCluDL) since it runs several
@@ -312,7 +312,7 @@ beta_hat, selected_ecdl = ensemble_clustered_inference_pvalue(
     fdr=fwer_target,
 )
 
-#############################################################################
+# %%
 # Results
 # -------
 #
@@ -342,7 +342,7 @@ titles.append("EnCluDL")
 
 plot(maps, titles)
 
-#############################################################################
+# %%
 # Analysis of the results
 # -----------------------
 # As argued in the first section of this example, standard inference methods that

--- a/examples/plot_conditional_vs_marginal_xor_data.py
+++ b/examples/plot_conditional_vs_marginal_xor_data.py
@@ -18,7 +18,7 @@ from sklearn.svm import SVC
 
 from hidimstat import CFI
 
-#############################################################################
+# %%
 # To solve the XOR problem, we will use a Support Vector Classier (SVC) with Radial Basis Function (RBF) kernel. The decision function of
 # the fitted model shows that the model is able to separate the two classes.
 rng = np.random.RandomState(0)
@@ -36,9 +36,9 @@ model.fit(X_train, y_train)
 Z = model.decision_function(np.c_[xx.ravel(), yy.ravel()])
 
 
-#############################################################################
-#  Visualizing the decision function of the SVC
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# %%
+# Visualizing the decision function of the SVC
+# --------------------------------------------
 fig, ax = plt.subplots()
 ax.imshow(
     Z.reshape(xx.shape),
@@ -64,15 +64,15 @@ ax.set_title("Decision function of SVC with RBF kernel")
 plt.show()
 
 
-##############################################################################
+# %%
 # The decision function of the SVC shows that the model is able to learn the
 # non-linear decision boundary of the XOR problem. It also highlights that knowing
 # the value of both features is necessary to classify each sample correctly.
 
 
-###############################################################################
+# %%
 # Computing the conditional and marginal importance
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# -------------------------------------------------
 # We first compute the marginal importance by fitting univariate models on each feature.
 # Then, we compute the conditional importance using the CFI class. The univarariate
 # models don't perform above chance, since solving the XOR problem requires to use both
@@ -98,7 +98,7 @@ for i in range(X.shape[1]):
         feat_scores.append(univariate_model.score(X_test_univariate, y_test))
     marginal_scores.append(feat_scores)
 
-###########################################################################
+# %%
 
 importances = []
 for i, (train_index, test_index) in enumerate(cv.split(X)):
@@ -122,9 +122,9 @@ for i, (train_index, test_index) in enumerate(cv.split(X)):
 importances = np.array(importances).T
 
 
-#############################################################################
+# %%
 # Visualizing the importance scores
-# -----------------------------------------------------------------------
+# ---------------------------------
 # We will use boxplots to visualize the distribution of the importance scores.
 fig, axes = plt.subplots(1, 2, sharey=True, figsize=(6, 2.5))
 # Marginal scores boxplot
@@ -156,7 +156,7 @@ axes[1].axvline(x=0.0, color="k", linestyle="--", lw=3)
 plt.tight_layout()
 plt.show()
 
-########################################################################
+# %%
 # On the left, we can see that both features are not marginally important, since the
 # boxplots overlap with the chance level (accuracy = 0.5). On the right, we can see that
 # both features are conditionally important, since the importance scores are far from

--- a/examples/plot_dcrt_example.py
+++ b/examples/plot_dcrt_example.py
@@ -8,7 +8,7 @@ repetitions is set to 10. The metrics used are the type-I error and
 the power
 """
 
-#############################################################################
+# %%
 # Imports needed for this script
 # ------------------------------
 
@@ -22,7 +22,7 @@ from sklearn.linear_model import LassoCV
 from hidimstat import D0CRT
 from hidimstat._utils.scenario import multivariate_simulation
 
-#############################################################################
+# %%
 # Processing the computations
 # ---------------------------
 
@@ -88,7 +88,7 @@ for sim_ind in range(10):
         }
     )
 
-#############################################################################
+# %%
 # Plotting the comparison
 # -----------------------
 
@@ -105,7 +105,7 @@ sns.boxplot(data=df_plot, x="model", y="power", ax=ax[1], hue="model")
 sns.despine()
 plt.show()
 
-#############################################################################
+# %%
 # Both methods empirically control the type-I error. In addition, it can
 # be observed that the power of the Random Forest model is generally higher
 # than that of the Lasso model, indicating a better ability to detect true

--- a/examples/plot_diabetes_variable_importance_example.py
+++ b/examples/plot_diabetes_variable_importance_example.py
@@ -42,7 +42,7 @@ References
 
 """
 
-#############################################################################
+# %%
 # Imports needed for this script
 # ------------------------------
 import matplotlib.pyplot as plt
@@ -57,14 +57,15 @@ from sklearn.model_selection import KFold
 
 from hidimstat import CFI, LOCO, PFI
 
-#############################################################################
+# %%
 # Load the diabetes dataset
 # -------------------------
 diabetes = load_diabetes()
 X, y = diabetes.data, diabetes.target
 # Encode sex as binary
 X[:, 1] = (X[:, 1] > 0.0).astype(int)
-#############################################################################
+
+# %%
 # Fit a baseline model on the diabetes dataset
 # --------------------------------------------
 # We use a Ridge regression model with a 10-fold cross-validation to fit the
@@ -85,7 +86,8 @@ for i, (train_index, test_index) in enumerate(kf.split(X)):
 
     print(f"Fold {i}: {score}")
     print(f"Fold {i}: {mse}")
-#############################################################################
+
+# %%
 # Fit a baselien model on the diabetes dataset
 # --------------------------------------------
 # We use a Ridge regression model with a 10-fold cross-validation to fit the
@@ -107,7 +109,7 @@ for i, (train_index, test_index) in enumerate(kf.split(X)):
     print(f"Fold {i}: {score}")
     print(f"Fold {i}: {mse}")
 
-#############################################################################
+# %%
 # Measure the importance of variables using the CFI method
 # --------------------------------------------------------
 
@@ -129,7 +131,7 @@ for i, (train_index, test_index) in enumerate(kf.split(X)):
     importance = cfi.importance(X_test, y_test)
     cfi_importance_list.append(importance)
 
-#############################################################################
+# %%
 # Measure the importance of variables using the LOCO method
 # ---------------------------------------------------------
 
@@ -148,7 +150,7 @@ for i, (train_index, test_index) in enumerate(kf.split(X)):
     loco_importance_list.append(importance)
 
 
-#############################################################################
+# %%
 # Measure the importance of variables using the permutation method
 # ----------------------------------------------------------------
 
@@ -169,7 +171,7 @@ for i, (train_index, test_index) in enumerate(kf.split(X)):
     pfi_importance_list.append(importance)
 
 
-#############################################################################
+# %%
 # Define a function to compute the p-value from importance values
 # ---------------------------------------------------------------
 def compute_pval(vim):
@@ -179,10 +181,9 @@ def compute_pval(vim):
     return np.clip(pval, 1e-10, 1 - 1e-10)
 
 
-#############################################################################
+# %%
 # Analyze the results
 # -------------------
-
 
 cfi_vim_arr = np.array([x["importance"] for x in cfi_importance_list]) / 2
 cfi_pval = compute_pval(cfi_vim_arr)

--- a/examples/plot_fmri_data_example.py
+++ b/examples/plot_fmri_data_example.py
@@ -29,7 +29,7 @@ As demonstrated in :footcite:t:`chevalier2021decoding`, it produces relevant
 predictive regions across various tasks.
 """
 
-#############################################################################
+# %%
 # Imports needed for this script
 # ------------------------------
 import resource
@@ -76,7 +76,7 @@ resource.setrlimit(resource.RLIMIT_AS, (new_soft_limit, new_hard_limit))
 n_job = 1
 
 
-#############################################################################
+# %%
 # Function to fetch and preprocess Haxby dataset
 # ----------------------------------------------
 def preprocess_haxby(subject=2, memory=None):
@@ -119,7 +119,7 @@ def preprocess_haxby(subject=2, memory=None):
     return Bunch(X=X, y=y, groups=groups, bg_img=bg_img, masker=masker)
 
 
-#############################################################################
+# %%
 # Gathering and preprocessing Haxby dataset for a given subject
 # -------------------------------------------------------------
 # The `preprocess_haxby` function make the preprocessing of the Haxby dataset,
@@ -131,9 +131,9 @@ data = preprocess_haxby(subject=2)
 X, y, groups, masker = data.X, data.y, data.groups, data.masker
 mask = masker.mask_img_.get_fdata().astype(bool)
 
-#############################################################################
+# %%
 # Initializing FeatureAgglomeration object that performs the clustering
-# -------------------------------------------------------------------------
+# ---------------------------------------------------------------------
 # For fMRI data taking 500 clusters is generally a good default choice.
 
 n_clusters = 500
@@ -144,11 +144,11 @@ connectivity = image.grid_to_graph(n_x=n_x, n_y=n_y, n_z=n_z, mask=mask)
 # Initializing FeatureAgglomeration object.
 ward = FeatureAgglomeration(n_clusters=n_clusters, connectivity=connectivity)
 
-#############################################################################
+# %%
 # Making the inference with several algorithms
 # --------------------------------------------
 
-#############################################################################
+# %%
 # First, we try to recover the discriminative pattern by computing
 # p-values from desparsified lasso.
 # Due to the size of the X, it's not possible to use this method with a limit
@@ -166,7 +166,7 @@ except MemoryError as err:
     one_minus_pval_dl = None
     print("As expected, Desparsified Lasso uses too much memory.")
 
-#############################################################################
+# %%
 # Now, the clustered inference algorithm which combines parcellation
 # and high-dimensional inference (c.f. References).
 ward_, beta_hat, theta_hat, omega_diag = clustered_inference(
@@ -176,7 +176,7 @@ beta_hat, pval_cdl, _, one_minus_pval_cdl, _ = clustered_inference_pvalue(
     X.shape[0], None, ward_, beta_hat, theta_hat, omega_diag
 )
 
-#############################################################################
+# %%
 # Below, we run the ensemble clustered inference algorithm which adds a
 # randomization step over the clustered inference algorithm (c.f. References).
 # To make the example as short as possible we take `n_bootstraps=5`
@@ -208,7 +208,7 @@ beta_hat, selected = ensemble_clustered_inference_pvalue(
     fdr=0.1,
 )
 
-#############################################################################
+# %%
 # Plotting the results
 # --------------------
 # To allow a better visualization of the disciminative pattern we will plot
@@ -221,14 +221,14 @@ beta_hat, selected = ensemble_clustered_inference_pvalue(
 n_samples, n_features = X.shape
 target_fwer = 0.1
 
-#############################################################################
+# %%
 # We now translate the FWER target into a z-score target.
 # For the permutation test methods we do not need any additional correction
 # since the p-values are already adjusted for multiple testing.
 
 zscore_threshold_corr = zscore_from_pval((target_fwer / 2))
 
-#############################################################################
+# %%
 # Other methods need to be corrected. We consider the Bonferroni correction.
 # For methods that do not reduce the feature space, the correction
 # consists in dividing by the number of features.
@@ -236,14 +236,14 @@ zscore_threshold_corr = zscore_from_pval((target_fwer / 2))
 correction = 1.0 / n_features
 zscore_threshold_no_clust = zscore_from_pval((target_fwer / 2) * correction)
 
-#############################################################################
+# %%
 # For methods that parcelates the brain into groups of voxels, the correction
 # consists in dividing by the number of parcels (or clusters).
 
 correction_clust = 1.0 / n_clusters
 zscore_threshold_clust = zscore_from_pval((target_fwer / 2) * correction_clust)
 
-#############################################################################
+# %%
 # Now, we can plot the thresholded z-score maps by translating the
 # p-value maps estimated previously into z-score maps and using the
 # suitable threshold. For a better readability, we make a small function
@@ -292,7 +292,7 @@ plot_map(selected, 0.5, "EnCluDL", vmin=-1, vmax=1)
 # running as a script outside IPython
 show()
 
-#############################################################################
+# %%
 # Analysis of the results
 # -----------------------
 # As advocated in introduction, the methods that do not reduce the original
@@ -309,7 +309,7 @@ show()
 # spurious discoveries.
 
 
-#############################################################################
+# %%
 # References
 # ----------
 # .. footbibliography::

--- a/examples/plot_importance_classification_iris.py
+++ b/examples/plot_importance_classification_iris.py
@@ -36,9 +36,9 @@ from sklearn.svm import SVC
 
 from hidimstat import CFI, PFI
 
-########################################################################
+# %%
 # Load the iris dataset and add a spurious feature
-# ----------------------------------------------------------------------
+# ------------------------------------------------
 # We load the iris dataset and add a spurious feature that is a linear combination of
 # the petal length, width amd some noise but not related to the target. The spurious feature
 # allows to illustrate that `PFI` is not robust to spurious features,
@@ -53,9 +53,9 @@ X = np.hstack([X, spurious_feat.reshape(-1, 1)])
 dataset.feature_names = dataset.feature_names + ["spurious_feat"]
 
 
-############################################################################
+# %%
 # Measure variable importance
-# --------------------------------------------------------------------------
+# ---------------------------
 # Since both methods compute variable importance as a loss difference, they
 # require a K-fold cross-fitting. Computing the importance for each fold is
 # embarassingly parallel. For this reason, we encapsulate the main computations in a
@@ -106,7 +106,7 @@ def run_one_fold(X, y, model, train_index, test_index, vim_name="CFI", groups=No
     )
 
 
-##############################################################################
+# %%
 # We use two different classifiers: LR with cross-validation and SVC with a RBF kernel. We
 # then compute the importance for each (importance method, classifier, fold)
 # combination, in parallel.
@@ -128,7 +128,7 @@ out_list = Parallel(n_jobs=5)(
 df = pd.concat(out_list)
 
 
-##########################################################################
+# %%
 # Using the importance values, we can compute the p-value of each feature. As we will
 # see, the p-values computed with `PFI` are not valid since the method
 # does not provide type-1 error control.
@@ -164,9 +164,9 @@ threshold = 0.05
 df_pval = compute_pval(df, threshold=threshold)
 
 
-############################################################################
+# %%
 # Visualization of the results
-# --------------------------------------------------------------------------
+# ----------------------------
 def plot_results(df_importance, df_pval):
     fig, axes = plt.subplots(1, 2, figsize=(6, 3), sharey=True)
     for method, ax in zip(["CFI", "PFI"], axes):
@@ -233,7 +233,7 @@ def plot_results(df_importance, df_pval):
 plot_results(df, df_pval)
 
 
-####################################################################################
+# %%
 # The boxplot shows the importance of each feature, with colors indicating the
 # classifier used. A star marks the features that have a p-value (computed with a
 # t-test) below 0.05. As expected, the spurious feature is not selected by CFI,
@@ -245,9 +245,9 @@ plot_results(df, df_pval)
 # kernel, which would be feasible with more data.
 
 
-#########################################################################
+# %%
 # Measuring the importance of groups of features
-# -----------------------------------------------------------------------
+# ----------------------------------------------
 # In the example above, CFI did not select some features. This is because it
 # measures conditional importance, which is the additional independent information a
 # feature provides knowing all the other features. When features are highly correlated,

--- a/examples/plot_knockoff_aggregation.py
+++ b/examples/plot_knockoff_aggregation.py
@@ -13,7 +13,7 @@ by :footcite:t:`pmlr-v119-nguyen20a` and :footcite:t:`Ren_2023` to derandomize
 inference.
 """
 
-#############################################################################
+# %%
 # Imports needed for this script
 # ------------------------------
 
@@ -34,9 +34,9 @@ from hidimstat.statistical_tools.multiple_testing import fdp_power
 from hidimstat._utils.scenario import multivariate_simulation
 
 
-#############################################################################
+# %%
 # Data simulation
-# -----------------------
+# ---------------
 # The comparison of the three methods relies on evaluating the
 # False Discovery Proportion (FDP) and statistical power. Assessing these
 # metrics requires knowledge of the actual data-generating process.
@@ -70,7 +70,7 @@ rng = check_random_state(seed)
 seed_list = rng.randint(1, np.iinfo(np.int32).max, runs)
 
 
-#######################################################################
+# %%
 # Define the function for running the three procedures on the same data
 # ---------------------------------------------------------------------
 def single_run(
@@ -138,7 +138,7 @@ def single_run(
     return fdp_mx, fdp_pval, fdp_eval, power_mx, power_pval, power_eval
 
 
-#######################################################################
+# %%
 # Define the function for plotting the result
 # -------------------------------------------
 def plot_results(bounds, fdr, n_samples, n_features, power=False):
@@ -173,7 +173,7 @@ def plot_results(bounds, fdr, n_samples, n_features, power=False):
         plt.legend(loc="best")
 
 
-#######################################################################
+# %%
 # Define the function for evaluate the effect of the population
 # -------------------------------------------------------------
 def effect_number_samples(n_samples):
@@ -217,27 +217,27 @@ def effect_number_samples(n_samples):
     plt.show()
 
 
-#######################################################################
+# %%
 # Aggregation methods provide a more stable inference
 # ---------------------------------------------------
 effect_number_samples(n_samples=n_samples)
 
-#######################################################################
+# %%
 # By repeating the model-X Knockoffs, we can see that instability
 # of the inference. Additionally, we can see that the aggregation method
 # is more stable. However, the e-values aggregation is more conservative,
 # i.e. the exepect variables of importance is not find.
 
-#######################################################################
+# %%
 # Limitation of the aggregation methods
 # -------------------------------------
 effect_number_samples(n_samples=50)
 
-#######################################################################
+# %%
 # One important point of this method is that they require enough samples to
 # estimate the distribution of each feature.
 
-#######################################################################
+# %%
 # References
 # ----------
 # .. footbibliography::

--- a/examples/plot_knockoffs_wisconsin.py
+++ b/examples/plot_knockoffs_wisconsin.py
@@ -16,9 +16,9 @@ seed = 0
 rng = np.random.RandomState(seed)
 
 
-########################################################################################
+# %%
 # Load the breast cancer dataset
-# ------------------------------------------------------
+# ------------------------------
 # There are 569 samples and 30 features that correspond to tumor attributes.
 # The downstream task is to classify tumors as benign or malignant. We leave out 10% of
 # the data to evaluate the performance of the Logistic Lasso (Logistic Regression with
@@ -43,9 +43,9 @@ n_test = X_test.shape[0]
 feature_names = [str(name) for name in data.feature_names]
 
 
-#############################################################################
+# %%
 # Selecting variables with the Logistic Lasso
-# -----------------------------------------------------------
+# -------------------------------------------
 # We want to select variables that are relevant to the outcome, i.e. tumor
 # charateristics that are associated with tumor malignance. We start off by applying a
 # classical method using Lasso logistic regression and retaining variables with non-null
@@ -67,9 +67,9 @@ for i in selected_lasso:
     print(f"{feature_names[i]:<30} | {clf.coef_[0][i]:>10.3f}")
 
 
-#############################################################################
+# %%
 # Evaluating the rejection set
-# ------------------------------------------
+# ----------------------------
 # Since we do not have the ground truth for the selected variables (i.e. we do not know
 # the relationship between the tumor characteristics and the the malignance of the tumor
 # ), we cannot evaluate this selection set directly. To investigate the reliability of
@@ -92,7 +92,7 @@ noisy_train = np.concatenate(noises_train, axis=1)
 noisy_test = np.concatenate(noises_test, axis=1)
 
 
-#################################################################################
+# %%
 # There are 180 features, 30 of them are real and 150 of them are fake and independent
 # of the outcome. We now apply the Lasso (with cross-validation to select the best
 # regularization parameter) to the noisy dataset and observe the results:
@@ -126,16 +126,16 @@ num_false_discoveries = np.sum(
 print(f"The Lasso makes at least {num_false_discoveries} False Discoveries!!")
 
 
-#################################################################################
+# %%
 # The Lasso selects many spurious variables that are not directly related to the outcome.
 # To mitigate this problem, we can use one of the statistically controlled variable
 # selection methods implemented in hidimstat. This ensures that the proportion of False
 # Discoveries is below a certain bound set by the user in all scenarios.
 
 
-#############################################################################
+# %%
 # Controlled variable selection with Knockoffs
-# ----------------------------------------------------
+# --------------------------------------------
 # We use the Model-X Knockoff procedure to control the FDR (False Discovery Rate). The
 # selection of variables is based on the Lasso Coefficient Difference (LCD) statistic
 # :footcite:t:`candes2018panning`.
@@ -166,9 +166,9 @@ num_false_discoveries = np.sum(selected >= p)
 print(f"Knockoffs make at least {num_false_discoveries} False Discoveries")
 
 
-##############################################################################
+# %%
 # Visualizing the results
-# ----------------------------------------------------
+# -----------------------
 # We can compare the selection sets obtained by the two methods. In addition to the
 # binary selection (selected or not), we can also visualize the the KO statistic
 # along with the selection threshold for the knockoffs and the absolute value of the
@@ -229,7 +229,7 @@ plt.tight_layout()
 plt.show()
 
 
-###############################################################################
+# %%
 # We can clearly see that the knockoffs procedure is more conservative than the Lasso
 # and rejects the spurious features while many of them are selected by the Lasso. It is
 # also interesting to note that some of the selected variables (with the high KO
@@ -237,7 +237,7 @@ plt.show()
 # with the largest Lasso coefficients.
 
 
-#################################################################################
+# %%
 # References
-# ---------------------------------------------------------------------------
+# ----------
 # .. footbibliography::

--- a/examples/plot_model_agnostic_importance.py
+++ b/examples/plot_model_agnostic_importance.py
@@ -37,9 +37,9 @@ from sklearn.svm import SVC
 
 from hidimstat import D0CRT, LOCO
 
-#############################################################################
+# %%
 # Generate data where classes are not linearly separable
-# --------------------------------------------------------------
+# ------------------------------------------------------
 rng = np.random.RandomState(0)
 X, y = make_circles(n_samples=500, noise=0.1, factor=0.6, random_state=rng)
 
@@ -57,15 +57,15 @@ ax.set_xlabel("X1")
 ax.set_ylabel("X2")
 plt.show()
 
-###############################################################################
+# %%
 # Define a linear and a non-linear estimator
 # ------------------------------------------
 non_linear_model = SVC(kernel="rbf", random_state=0)
 linear_model = LogisticRegressionCV(Cs=np.logspace(-3, 3, 5))
 
-###############################################################################
+# %%
 # Compute p-values using d0CRT
-# ---------------------------------------------------------------------------
+# ----------------------------
 # We first compute the p-values using d0CRT which performs a conditional independence
 # test (:math:`H_0: X_j \perp\!\!\!\perp y | X_{-j}`) for each variable. However,
 # this test is based on a linear model (LogisticRegression) and fails to reject the null
@@ -78,9 +78,9 @@ d0crt_non_linear = D0CRT(estimator=clone(non_linear_model), screening_threshold=
 d0crt_non_linear.fit_importance(X, y)
 pval_dcrt_non_linear = d0crt_non_linear.pvalues_
 
-################################################################################
+# %%
 # Compute p-values using LOCO
-# ---------------------------------------------------------------------------
+# ---------------------------
 # We then compute the p-values using LOCO
 # with a linear, and then a non-linear model. When using a
 # misspecified model, such as a linear model for this dataset, LOCO fails to reject the null
@@ -114,7 +114,7 @@ for train, test in cv.split(X):
     )
 
 
-################################################################################
+# %%
 # To select variables using LOCO, we compute the p-values using a t-test over the
 # importance scores.
 
@@ -138,9 +138,9 @@ df_pval = pd.DataFrame(
 df_pval["minus_log10_pval"] = -np.log10(df_pval["pval"])
 
 
-#################################################################################
+# %%
 # Plot the :math:`-log_{10}(pval)` for each method and variable
-# ---------------------------------------------------------------------------
+# -------------------------------------------------------------
 fig, ax = plt.subplots()
 sns.barplot(
     data=df_pval,
@@ -158,7 +158,7 @@ ax.legend()
 plt.show()
 
 
-#################################################################################
+# %%
 # As expected, when using linear models (d0CRT and LOCO-linear) that are misspecified,
 # the varibles are not selected. This highlights the benefit of using model-agnostic
 # methods such as LOCO, which allows for the use of models that are expressive enough
@@ -166,7 +166,7 @@ plt.show()
 # restricts it from capturing variable interactions.
 
 
-#################################################################################
+# %%
 # References
-# ---------------------------------------------------------------------------
+# ----------
 # .. footbibliography::

--- a/examples/plot_pitfalls_permutation_importance.py
+++ b/examples/plot_pitfalls_permutation_importance.py
@@ -30,7 +30,7 @@ from hidimstat.conditional_sampling import ConditionalSampler
 
 rng = np.random.RandomState(0)
 
-#############################################################################
+# %%
 # Load the California housing dataset and add a spurious feature
 # --------------------------------------------------------------
 # The California housing dataset is a regression dataset with 8 features. We add a
@@ -73,7 +73,7 @@ ax.set_xticklabels(labels=feature_names, fontsize=10, rotation=45)
 plt.tight_layout()
 plt.show()
 
-###############################################################################
+# %%
 # Fit a predictive model
 # ----------------------
 # We fit a neural network model to the California housing dataset. PFI is a
@@ -109,7 +109,7 @@ for train_index, test_index in kf.split(X):
 
 print(f"Cross-validation R2 score: {np.mean(scores):.3f} ± {np.std(scores):.3f}")
 
-#########################################################################
+# %%
 # Measure the importance of variables using the PFI method
 # --------------------------------------------------------
 # We use the `PermutationFeatureImportance` class to compute the PFI in a cross-fitting
@@ -169,16 +169,16 @@ fig.tight_layout()
 plt.show()
 
 
-################################################################################
+# %%
 # While the most important variables identified by PFI are plausible, such as the
 # geographic coordinates or the median income of the block group, it is not robust to
 # the presence of spurious features and misleadingly identifies the spurious feature as
 # important.
 
 
-###########################################################################
+# %%
 # A valid alternative: Condional Feature Importance
-# -----------------------------------------------------
+# -------------------------------------------------
 # The `ConditionalFeatureImportance` class computes permutations of the feature of
 # interest while conditioning on the other features. In other words, it shuffles the
 # intrinsic information of the feature of interest while leaving the information that is
@@ -233,11 +233,11 @@ plt.tight_layout()
 plt.show()
 
 
-###############################################################################
+# %%
 # Contrary to PFI, CFI does not identify the spurious feature as important.
 
 
-###############################################################################
+# %%
 # Extrapolation bias in PFI
 # -------------------------
 # One of the main pitfalls of PFI is that it leads to extrapolation bias, i.e., it
@@ -326,7 +326,7 @@ ax.set_ylabel("Longitude")
 plt.show()
 
 
-###############################################################################
+# %%
 # PFI is likely to generate samples that are unrealistic and outside of the training
 # data, leading to extrapolation bias. In contrast, CFI generates samples that respect
 # the conditional distribution of the feature of interest.


### PR DESCRIPTION
- uses  `# %%` as example dividers (simpler and shorter than repeats of an undetermined number of `#`)
- clean up some 'header' length that were longer than the title