### PR TITLE
fix instability of tests

### DIFF
--- a/test/test_base_variable_importance.py
+++ b/test/test_base_variable_importance.py
@@ -129,8 +129,7 @@ class TestSelectionFDR:
     def test_selection_fdr_default_1(self, set_100_variable_sorted):
         "test selection of the default"
         vi = set_100_variable_sorted
-        vi.pvalues_ = .5 * (1 + np.random.rand(vi.importances_.shape[0]))
-``` pvalues greater than 1 are non-sensical.
+        vi.pvalues_ = 0.5 * (1 + np.random.rand(vi.importances_.shape[0]))
         true_value = np.zeros_like(vi.importances_, dtype=bool)  # selected any
         selection = vi.fdr_selection(0.2)
         np.testing.assert_array_equal(true_value, selection)


### PR DESCRIPTION
 This is for fixing this error. 
 
 FAILED test/test_base_variable_importance.py::TestSelectionFDR::test_selection_fdr_default_1 - AssertionError: 
Arrays are not equal

Mismatched elements: 1 / 100 (1%)
 ACTUAL: array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False, False, False, False,...
 DESIRED: array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False, False, False, False,...