### PR TITLE
Remove warning: invalid escape sequence '\S'

### DIFF
--- a/src/hidimstat/statistical_tools/gaussian_knockoffs.py
+++ b/src/hidimstat/statistical_tools/gaussian_knockoffs.py
@@ -7,7 +7,7 @@ from hidimstat._utils.utils import check_random_state
 
 
 class GaussianKnockoffs:
-    """
+    r"""
     Generator for second-order Gaussian variables using the equi-correlated method.
     Creates synthetic variables that preserve the covariance structure of the original
     variables while ensuring conditional independence between the original and synthetic data.


### PR DESCRIPTION
When the documentation is built, there is the warning: 
<unknown>:10: SyntaxWarning: invalid escape sequence '\S'

This PR is for removing this PR.