### PR TITLE
Fix version for the upload in coverage

### DIFF
--- a/.github/workflows/call_publish_result.yml
+++ b/.github/workflows/call_publish_result.yml
@@ -96,7 +96,7 @@ jobs:
     # name for files
     env:
       OS: 'macos-latest'
-      PYTHON: '3.13'
+      PYTHON: '3.14'
     steps:
     # initialize the reposititory
     - uses: actions/checkout@v6


### PR DESCRIPTION
The actual error of the CI is:
> Run FILE_SIZE=$(stat -c%s "cov-results-${PYTHON}-os-${OS}/cov-${PYTHON}-os-${OS}.xml")
stat: cannot statx 'cov-results-3.13-os-macos-latest/cov-3.13-os-macos-latest.xml': No such file or directory
Error: Process completed with exit code 1.

https://github.com/mind-inria/hidimstat/actions/runs/21947203287/job/63388153211

This is because the version in the CI for codecov was not correct. 
I made a fix here. 
