### PR TITLE
[MAINT] dependencies spec 0 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Bug fixes
 Maintenance
 -----------
 
+* Update dependencies following SPEC 0 (PR #527)
+
 Contributors
 ------------
 

--- a/docs/tools/conf.py
+++ b/docs/tools/conf.py
@@ -224,4 +224,5 @@ nitpick_ignore = [
     # Found here
     # https://stackoverflow.com/questions/11417221/sphinx-autodoc-gives-warning-pyclass-reference-target-not-found-type-warning
     ("py:class", "type"),
+    ("py:class", "callable"),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,41 +46,47 @@ dependencies = [
 [project.optional-dependencies]
 # Requirements necessary for building the documentation
 doc = [
-    "matplotlib             >= 3.8.0,   < 4",
-    "nilearn                >= 0.11.0,  < 1",
-    "memory_profiler                       ",
-    "numpydoc               >= 1.0.0,   < 2",
-    "pydata_sphinx_theme    >= 0.15.1,  < 1",
-    "seaborn                >= 0.13,    < 1",
-    "sphinxcontrib-bibtex   >= 2.5.0,   < 3",
-    "sphinx                 >= 7.0.0,   < 9",
-    "sphinx-gallery         >= 0.17.0,  < 1",
-    "sphinx-prompt          >= 1.8.0,   < 2",
-    "tqdm                   >= 4.1.0,   < 5",
-    "mne                    >= 1.6.0",
-    "pooch                  >= 1.5.0, < 1.10",
-    "sphinx-copybutton",
+    "matplotlib             >= 3.9",
+    "nilearn                >= 0.11.0",
+    "memory_profiler        >= 0.61.0",
+    "numpydoc               >= 1.7",
+    "pydata_sphinx_theme    >= 0.15.3",
+    "seaborn                >= 0.13.2",
+    "sphinxcontrib-bibtex   >= 2.6.3",
+    "sphinx                 >= 7.3.3",
+    "sphinx-gallery         >= 0.17.0",
+    "sphinx-prompt          >= 1.9",
+    "tqdm                   >= 4.66.3",
+    "mne                    >= 1.7.0",
+    "pooch                  >= 1.8.1, < 1.10",
+    "sphinx-copybutton      >= 0.5.2",
 ]
-example = ["matplotlib >= 3.1.0,   < 4", "seaborn    >= 0.9,     < 1"]
-style = ["ruff  >= 0.14", "codespell >=2.4.0"]
+example = [
+    "matplotlib             >= 3.9",
+    "seaborn                >= 0.13.2"
+]
+style = [
+    "ruff                   >= 0.14",
+    "codespell              >= 2.4.0"
+]
 
 # For running unit and docstring tests
 test = [
-    "coverage       >= 6.0,     < 8",
-    "iniconfig      >= 0.1,     < 3",
-    "matplotlib     >= 3.8.0,   < 4",
-    "packaging      >= 14.0,    < 100",
-    "pytest         >= 8.0, < 10",
-    "pytest-cov     >= 5.0, < 8",
-    "pytest-durations >= 1.0.0, < 2",
-    "pytest-env     >= 1.0.0,   < 2",
-    "pytest-html    >= 4.0.0,   < 5",
-    "pytest-mpl     >= 0.14,    < 1",
-    "pytest-randomly >= 3.3.0, < 5",
-    "pytest-reportlog >= 0.2.1, < 2",
-    "pytest-timeout >= 2.3.1,   < 3",
-    "pytest-xdist[psutil] >= 3.4.0,  < 4",
-    "seaborn        >= 0.12,     < 1",
+    "coverage               >= 7.5",
+    "iniconfig              >= 2.0",
+    "matplotlib             >= 3.9",
+    "packaging              >= 24.1",
+    "pytest                 >= 8.1.2",
+    "pytest-cov             >= 5.0",
+    "pytest-durations       >= 1.3",
+    "pytest-env             >= 1.1.4",
+    "pytest-html            >= 4.2",
+    "pytest-mpl             >= 0.17",
+    "pytest-randomly        >= 3.16",
+    "pytest-reportlog       >= 1.0",
+    "pytest-timeout         >= 2.3.1",
+    "pytest-xdist[psutil]   >= 3.6.1",
+    "seaborn                >= 0.13.2",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,13 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.10, < 4"
+requires-python = ">=3.10"
 dependencies = [
-    "joblib       >= 1.2.0, < 2",
-    "numpy        >= 1.25,  < 3",
-    "pandas       >= 2.2,   < 3",
-    "scikit-learn >= 1.5,   < 1.9",
-    "scipy        >= 1.9.2, < 2",
-    "tqdm         >= 4.1.0, < 5",
+    "joblib       >= 1.4",
+    "pandas       >= 2.2",
+    "scikit-learn >= 1.6",
+    "scipy        >= 1.13",
+    "tqdm         >= 4.66.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Made a pass on the dependencies to implement the [SPEC 0](https://scientific-python.org/specs/spec-0000/) as discussed in the issue. 
 - bumped lower bounds in the oldest version that is less than 2 years old. 
 - removed upper bounds