### PR TITLE
[DOC] Inlcuded naming conventions in dev guidelines

### DIFF
--- a/tools/documentation_developer/developer_guidelines.rst
+++ b/tools/documentation_developer/developer_guidelines.rst
@@ -67,4 +67,8 @@ Naming
 ~~~~~~
 Files should follow the `snake case <https://en.wikipedia.org/wiki/Snake_case>` convention,
 and classes should follow the `upper camel case <https://en.wikipedia.org/wiki/Camel_case>`
-convention. Names should not contain acronyms and should instead include the full version.
+convention. Names should not contain acronyms and should instead include the full version,
+except for really long names, such as Distilled Conditional Randomization Test
+abbreviated as D0CRT, or names that are standard in the scientific community, such as 
+LOCO which stands for Leave One Covariate Out. Functions should be written in snake case,
+and should not contain acronyms similarly to classes.

--- a/tools/documentation_developer/developer_guidelines.rst
+++ b/tools/documentation_developer/developer_guidelines.rst
@@ -69,6 +69,6 @@ Files should follow the `snake case <https://en.wikipedia.org/wiki/Snake_case>` 
 and classes should follow the `upper camel case <https://en.wikipedia.org/wiki/Camel_case>`
 convention. Names should not contain acronyms and should instead include the full version,
 except for really long names, such as Distilled Conditional Randomization Test
-abbreviated as D0CRT, or names that are standard in the scientific community, such as 
+abbreviated as D0CRT, or names that are standard in the scientific community, such as
 LOCO which stands for Leave One Covariate Out. Functions should be written in snake case,
 and should not contain acronyms similarly to classes.

--- a/tools/documentation_developer/developer_guidelines.rst
+++ b/tools/documentation_developer/developer_guidelines.rst
@@ -59,3 +59,12 @@ test patterns help to ensure consistent behavior:
 * ``test_<method>_randomness_with_none``
 * ``test_<method>_reproducibility_with_integer``
 * ``test_<method>_reproducibility_with_rng``
+
+Writing Conventions
+-------------------
+
+Naming
+~~~~~~
+Files should follow the `snake case <https://en.wikipedia.org/wiki/Snake_case>` convention,
+and classes should follow the `upper camel case <https://en.wikipedia.org/wiki/Camel_case>`
+convention. Names should not contain acronyms and should instead include the full version.


### PR DESCRIPTION
Following #39, included naming conventions in developer guidelines: upper camel case for classes, and snake case for files, both without acronyms.