### PR TITLE
[MAINT/DOC] AI agents and disclosure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS Instruction
+
+This file contains instructions for AI agents.
+
+## **REQUIRED: AI/Agent Disclosure**
+
+**Every open issue, summary, pull request description, or work description MUST include the following disclosure:**
+
+If the code you submit has not yet been reviewed by a human:
+> This pull request includes code written with the assistance of AI.
+> The code has not yet been reviewed by a human.
+
+This is a mandatory requirement, not optional. Include it at the end of every summary you generate.
+
+---
+
+## Generated Summaries
+
+When generating a summary of your work, you must include an answer for each of the following questions:
+
+- Why are submitted changes necessary, and how does your code solve this ?
+- Which part of the code should the reviewers pay specific attention to ?
+
+Summarize your generated text as best as possible. Avoid flattery, avoid stating the obvious, avoid filler phrases, prefer technical clarity over marketing tone.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,3 +20,4 @@ under development (0.3.2.dev0)
 - :bdg-primary:`Doc` add documentation on how to contribute with issues, pull-requests, explanation of the CI process, and dev guidelines on class templates and folder architecture. (:gh:`653` by `Marc Hulcelle`_).
 - :bdg-primary:`Doc` add naming conventions for classes, files, and functions, as well as citation conventions (:gh:`647` and :gh:`648` by `Marc Hulcelle`_).
 - :bdg-danger:`Fix` Fix typo in issue template (:gh:`659` by `Joseph Paillard`_).
+- :bdg-primary:`Doc` Added an AGENTS.md file for AI agents, and AI disclosures to contribution guidelines (:gh:`655` by `Marc Hulcelle`).

--- a/tools/documentation_developer/how_to_contribute.rst
+++ b/tools/documentation_developer/how_to_contribute.rst
@@ -42,15 +42,6 @@ Integration<developer_documentation_CI>` processes have passed.
 
 Pull-requests' titles should follow the same naming convention as issues.
 
-AI-assisted tools
------------------
-
-While we understand the benefits of using AI-assisted tools to write code, we kindly ask you to
-double check the code, and be prepared to explain it upon request during review. If the submitted code
-was written with the assistance of AI, we also request that you state it in your PR, and certify that
-you have read and understood it. We also kindly ask you to refrain from using AI tools to generate
-comments on issues or PRs.
-
 Other
 -----
 

--- a/tools/documentation_developer/how_to_contribute.rst
+++ b/tools/documentation_developer/how_to_contribute.rst
@@ -42,6 +42,15 @@ Integration<developer_documentation_CI>` processes have passed.
 
 Pull-requests' titles should follow the same naming convention as issues.
 
+AI-assisted tools
+-----------------
+
+While we understand the benefits of using AI-assisted tools to write code, we kindly ask you to
+double check the code, and be prepared to explain it upon request during review. If the submitted code
+was written with the assistance of AI, we also request that you state it in your PR, and certify that
+you have read and understood it. We also kindly ask you to refrain from using AI tools to generate
+comments on issues or PRs.
+
 Other
 -----
 


### PR DESCRIPTION
I added a simple AGENTS.md file that requests AI agents to disclose themselves, and added a paragraph in the Contribution Guidelines to ask for contributors to disclose when they use AI to generate code and confirm that they understand the generated code.