### PR TITLE
fix: remove duplicate checkbox in documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -33,13 +33,6 @@ body:
   - type: textarea
     attributes:
       label: Additional context (e.g. screenshots, GIFs)
-  - type: checkboxes
-    attributes:
-        label: Please confirm that you have searched existing issues in the repo.
-        description: You can do this by searching https://github.com/mind-inria/hidimstat/issues and making sure the bug is not related to another existing issue.
-        options:
-            - label: 'Yes'
-              required: true
   - type: markdown
     attributes:
       value: Thank you for contributing !


### PR DESCRIPTION
## Summary

Fixes #662

Remove the duplicate "confirm you searched existing issues" checkbox from the documentation issue template.

## Changes

- **.github/ISSUE_TEMPLATE/documentation.yml** — Removed duplicate checkbox section (lines 36-42)

## Before/After

**Before:** Template had two identical checkboxes asking users to confirm they searched existing issues.

**After:** Template has only one checkbox (the first one), which is sufficient.

## Test plan

- [ ] Verify the documentation issue template renders correctly on GitHub
- [ ] Confirm only one checkbox appears in the template

---
