### PR TITLE
[MAINT] upper bound scikit-learn to 1.9 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,3 +20,4 @@ under development (0.3.2.dev0)
 - :bdg-primary:`Doc` add documentation on how to contribute with issues, pull-requests, explanation of the CI process, and dev guidelines on class templates and folder architecture. (:gh:`653` by `Marc Hulcelle`_).
 - :bdg-primary:`Doc` add naming conventions for classes, files, and functions, as well as citation conventions (:gh:`647` and :gh:`648` by `Marc Hulcelle`_).
 - :bdg-danger:`Fix` Fix typo in issue template (:gh:`659` by `Joseph Paillard`_).
+- :bdg-secondary:`Maint` temporary fix for the CI upper-bounding scikit-learn to 1.9.0 (:gh:`669` by `Joseph Paillard`_).

--- a/README.rst
+++ b/README.rst
@@ -80,9 +80,8 @@ HiDimStat requires:
 
 - Python (>= |PythonMinVersion|)
 - joblib (>= |JoblibMinVersion|)
-- NumPy (>= |NumPyMinVersion|)
 - Pandas (>= |PandasMinVersion|)
-- Scikit-learn (>= |SklearnMinVersion|)
+- Scikit-learn (>= |SklearnMinVersion|, < 1.9)
 - SciPy (>= |SciPyMinVersion|)
 
 HiDimStat's plotting capabilities require Matplotlib (>= |MatplotlibMinVersion|).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.10"
 dependencies = [
     "joblib       >= 1.4",
     "pandas       >= 2.2",
-    "scikit-learn >= 1.6",
+    "scikit-learn >= 1.6, < 1.9",
     "scipy        >= 1.13",
     "tqdm         >= 4.66.3",
 ]


### PR DESCRIPTION
Temporary fix of the CI while we adapt to the latest scikit-learn release