### PR TITLE
[MAINT] remove poosh dependency upper-bound

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,3 +21,4 @@ under development (0.3.2.dev0)
 - :bdg-primary:`Doc` add naming conventions for classes, files, and functions, as well as citation conventions (:gh:`647` and :gh:`648` by `Marc Hulcelle`_).
 - :bdg-danger:`Fix` Fix typo in issue template (:gh:`659` by `Joseph Paillard`_).
 - :bdg-secondary:`Maint` temporary fix for the CI upper-bounding scikit-learn to 1.9.0 (:gh:`669` by `Joseph Paillard`_).
+- :bdg-secondary:`Maint` remove pinned poosh dependency (problem with somato dataset solved) (:gh:`670` by `Joseph Paillard`_).

--- a/examples/plot_meg_somato.py
+++ b/examples/plot_meg_somato.py
@@ -34,14 +34,6 @@ recovery from spatio-temporal data.
 import mne
 import numpy as np
 from mne.datasets import somato
-from mne.datasets.utils import MNE_DATASETS
-
-# MNE <= 1.11.0 ships a somato dataset archive (version=7) that is no longer supported.
-# TODO: remove once mne >= 1.12 is used.
-# Fix presented in https://github.com/mne-tools/mne-python/pull/13630
-if MNE_DATASETS["somato"]["url"].endswith("version=7"):
-    MNE_DATASETS["somato"]["hash"] = "md5:9a191907b326b9402341ee7a0d1240d8"
-    MNE_DATASETS["somato"]["url"] = "https://osf.io/download/tp4sg?version=8"
 
 cond = "somato"
 data_path = somato.data_path(verbose=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.10"
 dependencies = [
     "joblib       >= 1.4",
     "pandas       >= 2.2",
-    "scikit-learn >= 1.6",
+    "scikit-learn >= 1.6, < 1.9",
     "scipy        >= 1.13",
     "tqdm         >= 4.66.3",
 ]
@@ -58,7 +58,6 @@ doc = [
     "sphinx-prompt          >= 1.9",
     "tqdm                   >= 4.66.3",
     "mne                    >= 1.7.0",
-    "pooch                  >= 1.8.1, < 1.10",
     "sphinx-copybutton      >= 0.5.2",
     "sphinx-design          >= 0.5.0",
     "pyyaml                 >= 6.0",


### PR DESCRIPTION
We used to have problems loading the somato dataset from mne-python. This should be solved in the latest release of mne-python: https://github.com/mne-tools/mne-python/pull/13630 