### PR TITLE
[FIX] Speed up library

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,3 +23,4 @@ under development (0.3.2.dev0)
 - :bdg-primary:`Doc` Added an AGENTS.md file for AI agents, and AI disclosures to contribution guidelines (:gh:`655` by `Marc Hulcelle`).
 - :bdg-secondary:`Maint` added a maintenance-related issue template (:gh:`666` by `Marc Hulcelle`_).
 - :bdg-secondary:`Maint` temporary fix for the CI upper-bounding scikit-learn to 1.9.0 (:gh:`669` by `Joseph Paillard`_).
+- :bdg-danger:`Fix` Fixed unnecessary copy operations of X when only a slice view is needed (:gh:`646` by `Marc Hulcelle`_).

--- a/src/hidimstat/_utils/utils.py
+++ b/src/hidimstat/_utils/utils.py
@@ -37,6 +37,18 @@ def _check_vim_predict_method(method):
         )
 
 
+def _generate_mask(array_size, indexes, select_indices=True):
+    """
+    Generates a mask to select indexes or its opposite.
+    """
+    if select_indices:
+        mask = np.zeros(array_size, dtype=bool)
+    else:
+        mask = np.ones(array_size, dtype=bool)
+    mask[indexes] = select_indices
+    return mask
+
+
 def get_fitted_attributes(cls):
     """
     Get all attributes from a class that end with a single underscore

--- a/src/hidimstat/_utils/utils.py
+++ b/src/hidimstat/_utils/utils.py
@@ -37,7 +37,7 @@ def _check_vim_predict_method(method):
         )
 
 
-def _generate_mask_group_mask(array_size, indexes, selected=True):
+def _generate_group_mask(array_size, indexes, selected=True):
     """
     Generates a mask to select indexes or its opposite.
     """

--- a/src/hidimstat/conditional_feature_importance.py
+++ b/src/hidimstat/conditional_feature_importance.py
@@ -5,6 +5,7 @@ from sklearn.linear_model import LogisticRegressionCV, RidgeCV
 from sklearn.metrics import mean_squared_error
 
 from hidimstat._utils.docstring import _aggregate_docstring
+from hidimstat._utils.utils import _generate_mask
 from hidimstat.base_perturbation import BasePerturbation, BasePerturbationCV
 from hidimstat.samplers.conditional_sampling import ConditionalSampler
 
@@ -195,8 +196,11 @@ class CFI(BasePerturbation):
         """Fit a single imputation model, for a single group of features. This method
         is parallelized.
         """
-        X_j = X[:, features_groups_ids].copy()
-        X_minus_j = np.delete(X, features_groups_ids, axis=1)
+        X_j = X[:, features_groups_ids]
+        mask = _generate_mask(
+            X.shape[1], features_groups_ids, select_indices=False
+        )
+        X_minus_j = X[:, mask]
         estimator.fit(X_minus_j, X_j)
         return estimator
 
@@ -224,10 +228,13 @@ class CFI(BasePerturbation):
         """Sample from the conditional distribution using a permutation of the
         residuals.
         """
-        X_j = X[:, self._features_groups_ids[features_group_id]].copy()
-        X_minus_j = np.delete(
-            X, self._features_groups_ids[features_group_id], axis=1
+        X_j = X[:, self._features_groups_ids[features_group_id]]
+        mask = _generate_mask(
+            X.shape[1],
+            self._features_groups_ids[features_group_id],
+            select_indices=False,
         )
+        X_minus_j = X[:, mask]
         return self._list_imputation_models[features_group_id].sample(
             X_minus_j,
             X_j,

--- a/src/hidimstat/conditional_feature_importance.py
+++ b/src/hidimstat/conditional_feature_importance.py
@@ -5,7 +5,7 @@ from sklearn.linear_model import LogisticRegressionCV, RidgeCV
 from sklearn.metrics import mean_squared_error
 
 from hidimstat._utils.docstring import _aggregate_docstring
-from hidimstat._utils.utils import _generate_mask
+from hidimstat._utils.utils import _generate_group_mask
 from hidimstat.base_perturbation import BasePerturbation, BasePerturbationCV
 from hidimstat.samplers.conditional_sampling import ConditionalSampler
 
@@ -197,8 +197,8 @@ class CFI(BasePerturbation):
         is parallelized.
         """
         X_j = X[:, features_groups_ids]
-        mask = _generate_mask(
-            X.shape[1], features_groups_ids, select_indices=False
+        mask = _generate_group_mask(
+            X.shape[1], features_groups_ids, selected=False
         )
         X_minus_j = X[:, mask]
         estimator.fit(X_minus_j, X_j)
@@ -229,10 +229,10 @@ class CFI(BasePerturbation):
         residuals.
         """
         X_j = X[:, self._features_groups_ids[features_group_id]]
-        mask = _generate_mask(
+        mask = _generate_group_mask(
             X.shape[1],
             self._features_groups_ids[features_group_id],
-            select_indices=False,
+            selected=False,
         )
         X_minus_j = X[:, mask]
         return self._list_imputation_models[features_group_id].sample(

--- a/src/hidimstat/desparsified_lasso.py
+++ b/src/hidimstat/desparsified_lasso.py
@@ -20,7 +20,7 @@ from sklearn.utils.validation import check_memory
 from hidimstat._utils.docstring import _aggregate_docstring
 from hidimstat._utils.regression import _alpha_max
 from hidimstat._utils.utils import (
-    _generate_mask,
+    _generate_group_mask,
     check_random_state,
     seed_estimator,
 )
@@ -516,14 +516,14 @@ def _joblib_compute_residuals(X, id_column, clf, gram, return_clf):
     n_samples, _ = X.shape
 
     # Removing the column to regress against the others
-    mask = _generate_mask(X.shape[1], id_column, select_indices=False)
+    mask = _generate_group_mask(X.shape[1], id_column, selected=False)
     X_minus_i = X[:, mask]
     X_i = X[:, id_column]
 
     clf.set_params(
         precompute=gram[
-            :, _generate_mask(gram.shape[0], id_column, select_indices=False)
-        ][_generate_mask(gram.shape[1], id_column, select_indices=False)]
+            :, _generate_group_mask(gram.shape[0], id_column, selected=False)
+        ][_generate_group_mask(gram.shape[1], id_column, selected=False)]
     )
     # Fitting the Lasso model and computing the residuals
     clf.fit(X_minus_i, X_i)

--- a/src/hidimstat/desparsified_lasso.py
+++ b/src/hidimstat/desparsified_lasso.py
@@ -19,7 +19,11 @@ from sklearn.utils.validation import check_memory
 
 from hidimstat._utils.docstring import _aggregate_docstring
 from hidimstat._utils.regression import _alpha_max
-from hidimstat._utils.utils import check_random_state, seed_estimator
+from hidimstat._utils.utils import (
+    _generate_mask,
+    check_random_state,
+    seed_estimator,
+)
 from hidimstat.base_variable_importance import BaseVariableImportance
 from hidimstat.statistical_tools.p_values import two_sided_pval_from_cb
 
@@ -512,13 +516,14 @@ def _joblib_compute_residuals(X, id_column, clf, gram, return_clf):
     n_samples, _ = X.shape
 
     # Removing the column to regress against the others
-    X_minus_i = np.delete(X, id_column, axis=1)
-    X_i = np.copy(X[:, id_column])
+    mask = _generate_mask(X.shape[1], id_column, select_indices=False)
+    X_minus_i = X[:, mask]
+    X_i = X[:, id_column]
 
     clf.set_params(
-        precompute=np.delete(
-            np.delete(gram, id_column, axis=0), id_column, axis=1
-        )
+        precompute=gram[
+            :, _generate_mask(gram.shape[0], id_column, select_indices=False)
+        ][_generate_mask(gram.shape[1], id_column, select_indices=False)]
     )
     # Fitting the Lasso model and computing the residuals
     clf.fit(X_minus_i, X_i)

--- a/src/hidimstat/distilled_conditional_randomization_test.py
+++ b/src/hidimstat/distilled_conditional_randomization_test.py
@@ -16,6 +16,7 @@ from sklearn.preprocessing import StandardScaler
 from hidimstat._utils.docstring import _aggregate_docstring
 from hidimstat._utils.utils import (
     _check_vim_predict_method,
+    _generate_mask,
     check_random_state,
     seed_estimator,
 )
@@ -666,7 +667,8 @@ def _joblib_fit(
     ----------
     .. footbibliography::
     """
-    X_minus_idx = np.delete(np.copy(X), idx, 1)
+    mask = _generate_mask(X.shape[1], idx, select_indices=False)
+    X_minus_idx = X[:, mask]
 
     # Distill X with least square loss. Use lasso_weights for d0CRT-logit as described
     # in :footcite:t:`nguyen2022conditional` equation (10).
@@ -748,7 +750,8 @@ def _joblib_distill(
     ----------
     .. footbibliography::
     """
-    X_minus_idx = np.delete(np.copy(X), idx, 1)
+    mask = _generate_mask(X.shape[1], idx, select_indices=False)
+    X_minus_idx = X[:, mask]
 
     # Distill X with least square loss
     if sigma_X is None:
@@ -765,13 +768,21 @@ def _joblib_distill(
         ) ** 2 / n_samples + alpha * np.linalg.norm(model_x.coef_, ord=1)
     else:
         # Distill X with sigma_X
-        sigma_temp = np.delete(np.copy(sigma_X), idx, 0)
+        sigma_temp = sigma_X[
+            _generate_mask(sigma_X.shape[0], idx, select_indices=False)
+        ]
         b = sigma_temp[:, idx]
-        A = np.delete(np.copy(sigma_temp), idx, 1)
+        A = sigma_temp[
+            :, _generate_mask(sigma_temp.shape[1], idx, select_indices=False)
+        ]
         coefs_X = np.linalg.solve(A, b)
         X_residual = X[:, idx] - np.dot(X_minus_idx, coefs_X)
         sigma2 = sigma_X[idx, idx] - np.dot(
-            np.delete(np.copy(sigma_X[idx, :]), idx), coefs_X
+            sigma_X[
+                idx,
+                _generate_mask(sigma_X.shape[1], idx, select_indices=False),
+            ],
+            coefs_X,
         )
 
     # Distill Y - calculate residual

--- a/src/hidimstat/distilled_conditional_randomization_test.py
+++ b/src/hidimstat/distilled_conditional_randomization_test.py
@@ -16,7 +16,7 @@ from sklearn.preprocessing import StandardScaler
 from hidimstat._utils.docstring import _aggregate_docstring
 from hidimstat._utils.utils import (
     _check_vim_predict_method,
-    _generate_mask,
+    _generate_group_mask,
     check_random_state,
     seed_estimator,
 )
@@ -667,7 +667,7 @@ def _joblib_fit(
     ----------
     .. footbibliography::
     """
-    mask = _generate_mask(X.shape[1], idx, select_indices=False)
+    mask = _generate_group_mask(X.shape[1], idx, selected=False)
     X_minus_idx = X[:, mask]
 
     # Distill X with least square loss. Use lasso_weights for d0CRT-logit as described
@@ -750,7 +750,7 @@ def _joblib_distill(
     ----------
     .. footbibliography::
     """
-    mask = _generate_mask(X.shape[1], idx, select_indices=False)
+    mask = _generate_group_mask(X.shape[1], idx, selected=False)
     X_minus_idx = X[:, mask]
 
     # Distill X with least square loss
@@ -762,18 +762,18 @@ def _joblib_distill(
     else:
         # Distill X with sigma_X
         sigma_temp = sigma_X[
-            _generate_mask(sigma_X.shape[0], idx, select_indices=False)
+            _generate_group_mask(sigma_X.shape[0], idx, selected=False)
         ]
         b = sigma_temp[:, idx]
         A = sigma_temp[
-            :, _generate_mask(sigma_temp.shape[1], idx, select_indices=False)
+            :, _generate_group_mask(sigma_temp.shape[1], idx, selected=False)
         ]
         coefs_X = np.linalg.solve(A, b)
         X_residual = X[:, idx] - np.dot(X_minus_idx, coefs_X)
         sigma2 = sigma_X[idx, idx] - np.dot(
             sigma_X[
                 idx,
-                _generate_mask(sigma_X.shape[1], idx, select_indices=False),
+                _generate_group_mask(sigma_X.shape[1], idx, selected=False),
             ],
             coefs_X,
         )

--- a/src/hidimstat/knockoffs.py
+++ b/src/hidimstat/knockoffs.py
@@ -16,7 +16,7 @@ from hidimstat.statistical_tools.aggregation import quantile_aggregation
 from hidimstat.statistical_tools.multiple_testing import fdr_threshold
 
 
-def set_alpha_max_lasso_path(estimator, X, X_tilde, y, n_alphas=20):
+def set_alpha_max_lasso_path(estimator, X_ko, n_features, y, n_alphas=20):
     """
     Configure a LassoCV estimator's regularization path for concatenated features.
 
@@ -33,10 +33,10 @@ def set_alpha_max_lasso_path(estimator, X, X_tilde, y, n_alphas=20):
     estimator : sklearn.linear_model.LassoCV
         LassoCV instance to configure. This function modifies estimator.alphas
         in-place and returns the same estimator.
-    X : array-like, shape (n_samples, n_features)
-        Original feature matrix.
-    X_tilde : array-like, shape (n_samples, n_features)
-        Knockoff/auxiliary feature matrix (must have same n_features as X).
+    X_ko : array-like, shape (n_samples, n_features)
+        Concatenation of original and knockoff feature matrix.
+    n_features : int
+        Number of features for matrix X_ko.
     y : array-like, shape (n_samples,)
         Target vector.
     n_alphas : int, default=20
@@ -62,9 +62,6 @@ def set_alpha_max_lasso_path(estimator, X, X_tilde, y, n_alphas=20):
         raise TypeError(
             "You should not use this function to configure the estimator"
         )
-
-    n_features = X.shape[1]
-    X_ko = np.column_stack([X, X_tilde])
     alpha_max = np.max(np.dot(X_ko.T, y)) / (2 * n_features)
     alphas = np.linspace(alpha_max * np.exp(-n_alphas), alpha_max, n_alphas)
     estimator.alphas = alphas
@@ -190,15 +187,13 @@ class ModelXKnockoff(BaseVariableImportance):
         )
 
         if self.estimator is None:
-            self.estimator_ = LassoCV(
+            self.estimator = LassoCV(
                 max_iter=200000, cv=KFold(n_splits=5, shuffle=True), tol=1e-6
             )
-        else:
-            self.estimator_ = clone(self.estimator)
-        self.estimator_ = seed_estimator(self.estimator_, self.random_state)
+        self.estimator = seed_estimator(self.estimator, self.random_state)
         self.estimators_ = Parallel(n_jobs, verbose=self.joblib_verbose)(
             delayed(self._joblib_fit_estimator)(
-                self.estimator_,
+                self.estimator,
                 X_,
                 X_tildes[i],
                 y,
@@ -393,6 +388,9 @@ class ModelXKnockoff(BaseVariableImportance):
         """
         Single fit of the estimator on the concatenated design matrix [X, X_tilde].
         """
+        n_features = X.shape[1]
+        X_ko = np.column_stack([X, X_tilde])
+
         estimator_ = clone(estimator)
         # Preconfigure the estimator if needed
         if preconfigure_lasso_path:
@@ -407,12 +405,11 @@ class ModelXKnockoff(BaseVariableImportance):
             else:
                 n_alphas = 10
             estimator_ = set_alpha_max_lasso_path(
-                estimator_, X, X_tilde, y, n_alphas=n_alphas
+                estimator_, X_ko, n_features, y, n_alphas=n_alphas
             )
 
-        X_ = np.column_stack([X, X_tilde])
         estimator_ = seed_estimator(estimator_, random_state)
-        estimator_.fit(X_, y)
+        estimator_.fit(X_ko, y)
         return estimator_
 
     @staticmethod

--- a/src/hidimstat/knockoffs.py
+++ b/src/hidimstat/knockoffs.py
@@ -33,8 +33,8 @@ def set_alpha_max_lasso_path(estimator, X_ko, n_features, y, n_alphas=20):
     estimator : sklearn.linear_model.LassoCV
         LassoCV instance to configure. This function modifies estimator.alphas
         in-place and returns the same estimator.
-    X_ko : array-like, shape (n_samples, n_features)
-        Concatenation of original and knockoff feature matrix.
+    X_ko : array-like, shape (n_samples, 2*n_features)
+        Column concatenation of original and knockoff feature matrices.
     n_features : int
         Number of features for matrix X_ko.
     y : array-like, shape (n_samples,)

--- a/src/hidimstat/knockoffs.py
+++ b/src/hidimstat/knockoffs.py
@@ -187,13 +187,15 @@ class ModelXKnockoff(BaseVariableImportance):
         )
 
         if self.estimator is None:
-            self.estimator = LassoCV(
+            self.estimator_ = LassoCV(
                 max_iter=200000, cv=KFold(n_splits=5, shuffle=True), tol=1e-6
             )
+        else:
+            self.estimator_ = clone(self.estimator)
         self.estimator = seed_estimator(self.estimator, self.random_state)
         self.estimators_ = Parallel(n_jobs, verbose=self.joblib_verbose)(
             delayed(self._joblib_fit_estimator)(
-                self.estimator,
+                self.estimator_,
                 X_,
                 X_tildes[i],
                 y,

--- a/src/hidimstat/leave_one_covariate_out.py
+++ b/src/hidimstat/leave_one_covariate_out.py
@@ -5,7 +5,7 @@ from sklearn.base import check_is_fitted, clone
 from sklearn.metrics import mean_squared_error
 
 from hidimstat._utils.docstring import _aggregate_docstring
-from hidimstat._utils.utils import _generate_mask, check_statistical_test
+from hidimstat._utils.utils import _generate_group_mask, check_statistical_test
 from hidimstat.base_perturbation import BasePerturbation, BasePerturbationCV
 
 
@@ -187,10 +187,10 @@ class LOCO(BasePerturbation):
         else:
             X_minus_j = X[
                 :,
-                _generate_mask(
+                _generate_group_mask(
                     X.shape[1],
                     self.features_groups_[key_features_group],
-                    select_indices=False,
+                    selected=False,
                 ),
             ]
         estimator.fit(X_minus_j, y)
@@ -205,10 +205,10 @@ class LOCO(BasePerturbation):
         del random_state  # not used (only there for API compatibility)
         X_minus_j = X[
             :,
-            _generate_mask(
+            _generate_group_mask(
                 X.shape[1],
                 self._features_groups_ids[features_group_id],
-                select_indices=False,
+                selected=False,
             ),
         ]
 

--- a/src/hidimstat/leave_one_covariate_out.py
+++ b/src/hidimstat/leave_one_covariate_out.py
@@ -5,7 +5,7 @@ from sklearn.base import check_is_fitted, clone
 from sklearn.metrics import mean_squared_error
 
 from hidimstat._utils.docstring import _aggregate_docstring
-from hidimstat._utils.utils import check_statistical_test
+from hidimstat._utils.utils import _generate_mask, check_statistical_test
 from hidimstat.base_perturbation import BasePerturbation, BasePerturbationCV
 
 
@@ -185,9 +185,14 @@ class LOCO(BasePerturbation):
                 columns=self.features_groups_[key_features_group]
             )
         else:
-            X_minus_j = np.delete(
-                X, self.features_groups_[key_features_group], axis=1
-            )
+            X_minus_j = X[
+                :,
+                _generate_mask(
+                    X.shape[1],
+                    self.features_groups_[key_features_group],
+                    select_indices=False,
+                ),
+            ]
         estimator.fit(X_minus_j, y)
         return estimator
 
@@ -198,9 +203,14 @@ class LOCO(BasePerturbation):
         Used in parallel.
         """
         del random_state  # not used (only there for API compatibility)
-        X_minus_j = np.delete(
-            X, self._features_groups_ids[features_group_id], axis=1
-        )
+        X_minus_j = X[
+            :,
+            _generate_mask(
+                X.shape[1],
+                self._features_groups_ids[features_group_id],
+                select_indices=False,
+            ),
+        ]
 
         y_pred_loco = getattr(
             self._list_estimators[features_group_id], self.method

--- a/test/test_knockoff.py
+++ b/test/test_knockoff.py
@@ -359,7 +359,7 @@ def test_preconfigure_LassoCV(rng):
     ):
         set_alpha_max_lasso_path(
             estimator=RidgeCV(),
-            X=rng.random((10, 10)),
+            X_ko=rng.random((10, 20)),
+            n_features=10,
             y=rng.random(10),
-            X_tilde=rng.random((10, 10)),
         )


### PR DESCRIPTION
There were several instances of copy operations on X when only slice views were needed. I made the changes using masks instead of a series of `np.copy` and `np.delete` operations.