### PR TITLE
[MAINT] fix test for conditional sampler 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,3 +25,4 @@ under development (0.3.2.dev0)
 - :bdg-secondary:`Maint` temporary fix for the CI upper-bounding scikit-learn to 1.9.0 (:gh:`669` by `Joseph Paillard`_).
 - :bdg-secondary:`Maint` remove pinned poosh dependency (problem with somato dataset solved) (:gh:`670` by `Joseph Paillard`_).
 - :bdg-secondary:`Maint`: remove extra term in variance of X-residual (DOCRT). See  [Reid et al., A Study of Error Variance Estimation in Lasso Regression 2016](https://arxiv.org/pdf/1311.5274) for reference. (:gh:`649` by `Joseph Paillard`_).
+- :bdg-secondary:`Maint`: Fix conditional sampling test by verifying that sampler produces diverse samples. (:gh:`692` by `Joseph Paillard`_).

--- a/test/samplers/test_conditional_sampling.py
+++ b/test/samplers/test_conditional_sampling.py
@@ -211,9 +211,14 @@ def test_group_case_binary_case():
     )
     assert X_3_perm.shape == (n_samples, X.shape[0], 2)
     for i in range(n_samples):
-        # TODO check why so good accuracy
-        assert 0.96 > accuracy_score(X_3_perm[i, :, 0], X[:, 3]) > 0.6
-        assert 0.96 > accuracy_score(X_3_perm[i, :, 1], X[:, 4]) > 0.6
+        assert accuracy_score(X_3_perm[i, :, 0], X[:, 3]) > 0.6
+        assert accuracy_score(X_3_perm[i, :, 1], X[:, 4]) > 0.6
+
+    # Check that the sampler still produce diversity: that not all samples are
+    # equal to the original data
+    assert not np.all(
+        [np.array_equal(X_3_perm[i], X[:, 3:]) for i in range(n_samples)]
+    )
 
 
 def test_sample_categorical(rng):


### PR DESCRIPTION
 - Remove the upper bound on the accuracy of the sampled 
 - Check that the generated samples are not all the same instead