### PR TITLE
[DOC] modify commit tag to build doc in draft PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     needs: [tests, get_information]
     if: |
       ${{ github.event.pull_request.draft == false
-          || contains(needs.get_information.outputs.COMMIT_MSG, '[doc ')
+          || contains(needs.get_information.outputs.COMMIT_MSG, '[doc]')
         }}
     permissions:
       pull-requests: write

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,3 +26,4 @@ under development (0.3.2.dev0)
 - :bdg-secondary:`Maint` remove pinned poosh dependency (problem with somato dataset solved) (:gh:`670` by `Joseph Paillard`_).
 - :bdg-secondary:`Maint`: remove extra term in variance of X-residual (DOCRT). See  [Reid et al., A Study of Error Variance Estimation in Lasso Regression 2016](https://arxiv.org/pdf/1311.5274) for reference. (:gh:`649` by `Joseph Paillard`_).
 - :bdg-secondary:`Maint`: Fix conditional sampling test by verifying that sampler produces diverse samples. (:gh:`692` by `Joseph Paillard`_).
+- :bdg-primary:`Doc`: Modify the commit tag allowing to build the documentation in draft PR (:gh:`695` by `Joseph Paillard`_).


### PR DESCRIPTION
Unfortunately, we cannot see the effect of the modification in this PR. The workflow called is the one from `main` so it the effect will only be visible after merging. 
https://github.com/mind-inria/hidimstat/blob/b04784d2d2847c2c3b3c40b1fad38cc2bb9fb0f2/.github/workflows/ci.yml#L5-L10


Use of AI tools:
- [x]  LLM tools were used to generate at least part of the content of this pull request. 