### PR TITLE
[ENH] Bootstrap for ALE confidence intervals

### DIFF
--- a/examples/plot_comparison_pdp_ale.py
+++ b/examples/plot_comparison_pdp_ale.py
@@ -94,7 +94,7 @@ pdp_axes = pdp.plot(X_test, features=1)
 # 2. ALE Plot
 ale = ALE(model, feature_names=X.columns)
 ale_axes = ale.plot(
-    X_test, features=1, grid_resolution=100, confidence_interval=False
+    X_test, features=1, grid_resolution=100, confidence_level=0
 )
 
 mean_pred = model.predict(X_test).mean()

--- a/src/hidimstat/visualization/accumulated_local_effects.py
+++ b/src/hidimstat/visualization/accumulated_local_effects.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from joblib import Parallel, delayed
 from scipy import stats
 from sklearn.utils.validation import check_is_fitted
 
@@ -73,9 +74,11 @@ def compute_ale_1d(
     feature_type,
     method="predict",
     grid_resolution="auto",
+    percentiles=(5, 95),
     confidence_interval=True,
     confidence_level=0.95,
-    percentiles=(5, 95),
+    n_bootstraps=20,
+    n_jobs=-1
 ):
     """Compute the 1D Accumulated Local Effect for a single numerical feature.
 
@@ -110,13 +113,17 @@ def compute_ale_1d(
           if the data contains many duplicate values or fewer unique points
           than requested.
 
+    percentiles : tuple of float, default=(5, 95)
+        The lower and upper percentile used to create the extreme values for the grid.
+        Must be in [0, 100].
     confidence_interval : bool, default=True
         Whether to compute the confidence intervals of the ALE curve.
     confidence_level : float, default=0.95
         The confidence level used to compute the confidence intervals (e.g., 0.95 for 95%).
-    percentiles : tuple of float, default=(5, 95)
-        The lower and upper percentile used to create the extreme values for the grid.
-        Must be in [0, 100].
+    n_bootstraps : int, default=20
+        Number of bootstrap samples to generate if `confidence_interval` is True.
+    n_jobs : int, default=-1
+        Number of jobs to run in parallel during bootstrapping. `-1` means using all processors.
 
     Returns
     -------
@@ -144,23 +151,10 @@ def compute_ale_1d(
                 f"Feature {feature_idx} has fewer than 2 unique quantile edges. Increase grid_resolution or check your data."
             )
 
-        bin_idx = _bin_indices(x, grid_values)
-
-        # For each sample, evaluate the model at the lower and upper edge of its bin
-        X_low = X.copy()
-        X_high = X.copy()
-        X_low[:, feature_idx] = grid_values[bin_idx]
-        X_high[:, feature_idx] = grid_values[bin_idx + 1]
-
-        local_effects = _predict_fn(estimator, X_high, method) - _predict_fn(
-            estimator, X_low, method
-        )  # shape (n_samples,)
-
-        combined_idx = bin_idx
-        combined_effects = local_effects
-        min_weight_bin = 0
+        X_bootstrap = X
 
     elif feature_type == "categorical":
+        # Grid defined by unique values
         if (
             not isinstance(percentiles, tuple)
             or len(percentiles) != 2
@@ -171,7 +165,6 @@ def compute_ale_1d(
                 "in [0, 100] in increasing order"
             )
 
-        # Grid defined by unique values
         low_bnd = np.percentile(x, percentiles[0])
         high_bnd = np.percentile(x, percentiles[1])
 
@@ -187,76 +180,106 @@ def compute_ale_1d(
                 f"Feature {feature_idx} has fewer than 2 unique values. Check your data."
             )
 
-        value_idx = np.digitize(x_filtered, grid_values) - 1
-
-        # For each sample, evaluate the model at the lower and upper edge of its bin
-        X_low = X_filtered.copy()
-        X_high = X_filtered.copy()
-        mask_low = x_filtered != grid_values[0]
-        mask_high = x_filtered != grid_values[-1]
-        X_low[mask_low, feature_idx] = grid_values[value_idx[mask_low] - 1]
-        X_high[mask_high, feature_idx] = grid_values[value_idx[mask_high] + 1]
-
-        local_effects_low = _predict_fn(
-            estimator, X_filtered[mask_low], method
-        ) - _predict_fn(estimator, X_low[mask_low], method)
-        local_effects_high = _predict_fn(
-            estimator, X_high[mask_high], method
-        ) - _predict_fn(estimator, X_filtered[mask_high], method)
-
-        # Average local effects within each bin
-        combined_idx = np.concatenate(
-            [value_idx[mask_low], value_idx[mask_high] + 1]
-        )
-        combined_effects = np.concatenate(
-            [local_effects_low, local_effects_high]
-        )
-        min_weight_bin = 1
+        X_bootstrap = X_filtered
 
     else:
         raise ValueError(
             "'feature_type' must be a string among 'continuous' and 'categorical'."
         )
 
-    # Average local effects within each bin
-    bin_counts = np.bincount(combined_idx, minlength=n_bins).astype(float)
-    bin_sums = np.bincount(
-        combined_idx, weights=combined_effects, minlength=n_bins
-    )
+    def _compute_ale_curve(X_sample):
+        """Internal closure to compute the ALE curve on a fixed grid."""
+        if feature_type == "continuous":
+            x_sample = X_sample[:, feature_idx]
+            bin_idx = _bin_indices(x_sample, grid_values)
 
-    mean_effects = np.zeros(n_bins, dtype=float)
-    non_zero = bin_counts > 0
-    mean_effects[non_zero] = bin_sums[non_zero] / bin_counts[non_zero]
+            # For each sample, evaluate the model at the lower and upper edge of its bin
+            X_low = X_sample.copy()
+            X_high = X_sample.copy()
+            X_low[:, feature_idx] = grid_values[bin_idx]
+            X_high[:, feature_idx] = grid_values[bin_idx + 1]
 
-    # Cumulative sum: uncentered ALE evaluated for each bin edge
-    if feature_type == "continuous":
-        ale = np.array([0, *np.cumsum(mean_effects)])
-    else:
-        ale = np.cumsum(mean_effects)
+            local_effects = _predict_fn(estimator, X_high, method) - _predict_fn(
+                estimator, X_low, method
+            )  # shape (n_samples,)
 
-    # Center: subtract the sample-weighted mean
-    ale_centers = (ale[1:] + ale[:-1]) / 2
-    ale -= np.sum(ale_centers * bin_counts[min_weight_bin:]) / bin_counts.sum()
+            combined_idx = bin_idx
+            combined_effects = local_effects
+            min_weight_bin = 0
+
+        else:
+            x_sample = X_sample[:, feature_idx]
+            value_idx = np.digitize(x_sample, grid_values) - 1
+
+            # For each sample, evaluate the model at the lower and upper edge of its bin
+            X_low = X_sample.copy()
+            X_high = X_sample.copy()
+            mask_low = x_sample != grid_values[0]
+            mask_high = x_sample != grid_values[-1]
+            X_low[mask_low, feature_idx] = grid_values[value_idx[mask_low] - 1]
+            X_high[mask_high, feature_idx] = grid_values[value_idx[mask_high] + 1]
+
+            local_effects_low = _predict_fn(
+                estimator, X_sample[mask_low], method
+            ) - _predict_fn(estimator, X_low[mask_low], method)
+            local_effects_high = _predict_fn(
+                estimator, X_high[mask_high], method
+            ) - _predict_fn(estimator, X_sample[mask_high], method)
+
+            # Average local effects within each bin
+            combined_idx = np.concatenate(
+                [value_idx[mask_low], value_idx[mask_high] + 1]
+            )
+            combined_effects = np.concatenate(
+                [local_effects_low, local_effects_high]
+            )
+            min_weight_bin = 1
+
+        # Average local effects within each bin
+        bin_counts = np.bincount(combined_idx, minlength=n_bins).astype(float)
+        bin_sums = np.bincount(
+            combined_idx, weights=combined_effects, minlength=n_bins
+        )
+
+        mean_effects = np.zeros(n_bins, dtype=float)
+        non_zero = bin_counts > 0
+        mean_effects[non_zero] = bin_sums[non_zero] / bin_counts[non_zero]
+
+        # Cumulative sum: uncentered ALE evaluated for each bin edge
+        if feature_type == "continuous":
+            ale_curve = np.array([0, *np.cumsum(mean_effects)])
+        else:
+            ale_curve = np.cumsum(mean_effects)
+
+        # Center: subtract the sample-weighted mean
+        ale_centers = (ale_curve[1:] + ale_curve[:-1]) / 2
+        ale_curve -= np.sum(ale_centers * bin_counts[min_weight_bin:]) / bin_counts.sum()
+
+        return ale_curve
+
+    # Base calculation
+    ale = _compute_ale_curve(X_bootstrap)
+    ale_err = None
 
     # Confidence interval
-    ale_err = None
     if confidence_interval:
-        sample_means = mean_effects[combined_idx]
-        squared_deviations = (combined_effects - sample_means) ** 2
-        sum_squared_deviations = np.bincount(
-            combined_idx, weights=squared_deviations, minlength=n_bins
-        )
+        if n_bootstraps < 1:
+            raise ValueError("'n_bootstrap' must be strictly greater than 0.")
 
-        var_of_mean = np.zeros(n_bins, dtype=float)
-        valid_bins = bin_counts > 1
-        var_of_mean[valid_bins] = sum_squared_deviations[valid_bins] / (
-            bin_counts[valid_bins] * (bin_counts[valid_bins] - 1)
-        )
+        def _bootstrap():
+            bootstrap_indices = np.random.default_rng().choice(
+                len(X_bootstrap), size=len(X_bootstrap), replace=True
+            )
+            return _compute_ale_curve(X_bootstrap[bootstrap_indices])
 
-        if feature_type == "continuous":
-            var_of_mean = np.array([0, *var_of_mean])
+        bootstrap_curves = Parallel(n_jobs=n_jobs)(
+            delayed(_bootstrap)() for _ in range(n_bootstraps)
+        )
+        bootstrap_curves = np.array(bootstrap_curves)
+
+        ale = np.mean(bootstrap_curves, axis=0)
         z_score = stats.norm.ppf(1 - (1 - confidence_level) / 2)
-        ale_err = z_score * np.sqrt(var_of_mean)
+        ale_err = z_score * np.std(bootstrap_curves, axis=0)
 
     return ale, grid_values, ale_err
 
@@ -521,9 +544,11 @@ class ALE:
         feature_type="auto",
         method="predict",
         grid_resolution="auto",
+        percentiles=(5, 95),
         confidence_interval=True,
         confidence_level=0.95,
-        percentiles=(5, 95),
+        n_bootstraps=20,
+        n_jobs=-1,
         cmap="viridis",
         **kwargs,
     ):
@@ -556,13 +581,18 @@ class ALE:
               strictly less than `grid_resolution` (or the auto-calculated value)
               if the data contains many duplicate values or fewer unique points
               than requested.
+
+        percentiles : tuple of float, default=(5, 95)
+            The lower and upper percentile used to create the extreme values for the grid.
+            Must be in [0, 100].
         confidence_interval : bool, default=True
             Whether to compute and display confidence intervals around the 1D ALE curve.
         confidence_level : float, default=0.95
             The confidence level used to compute the confidence intervals (e.g., 0.95 for 95%).
-        percentiles : tuple of float, default=(5, 95)
-            The lower and upper percentile used to create the extreme values for the grid.
-            Must be in [0, 100].
+        n_bootstraps : int, default=20
+            Number of bootstrap samples to generate if `confidence_interval` is True.
+        n_jobs : int, default=-1
+            Number of jobs to run in parallel during bootstrapping. `-1` means using all processors.
         cmap : str, default="viridis"
             Matplotlib colormap used for the 2D mesh plot.
         **kwargs
@@ -603,9 +633,11 @@ class ALE:
                     feature_idx=features,
                     feature_type=feature_type,
                     grid_resolution=grid_resolution,
+                    percentiles=percentiles,
                     confidence_interval=confidence_interval,
                     confidence_level=confidence_level,
-                    percentiles=percentiles,
+                    n_bootstraps=n_bootstraps,
+                    n_jobs=n_jobs,
                 )
                 result = {
                     "ale": ale,

--- a/src/hidimstat/visualization/accumulated_local_effects.py
+++ b/src/hidimstat/visualization/accumulated_local_effects.py
@@ -193,13 +193,14 @@ def compute_ale_1d(
 
     def _compute_ale_curve(X_sample):
         """Internal closure to compute the ALE curve on a fixed grid."""
+        X_j_sample = X_sample[:, feature_idx]
+        X_low = X_sample.copy()
+        X_high = X_sample.copy()
+
         if feature_type == "continuous":
-            X_j_sample = X_sample[:, feature_idx]
             bin_idx = _bin_indices(X_j_sample, grid_values)
 
             # For each sample, evaluate the model at the lower and upper edge of its bin
-            X_low = X_sample.copy()
-            X_high = X_sample.copy()
             X_low[:, feature_idx] = grid_values[bin_idx]
             X_high[:, feature_idx] = grid_values[bin_idx + 1]
 
@@ -212,12 +213,9 @@ def compute_ale_1d(
             min_weight_bin = 0
 
         else:
-            X_j_sample = X_sample[:, feature_idx]
             value_idx = np.digitize(X_j_sample, grid_values) - 1
 
             # For each sample, evaluate the model at the lower and upper edge of its bin
-            X_low = X_sample.copy()
-            X_high = X_sample.copy()
             mask_low = X_j_sample != grid_values[0]
             mask_high = X_j_sample != grid_values[-1]
             X_low[mask_low, feature_idx] = grid_values[value_idx[mask_low] - 1]

--- a/src/hidimstat/visualization/accumulated_local_effects.py
+++ b/src/hidimstat/visualization/accumulated_local_effects.py
@@ -68,6 +68,104 @@ def _predict_fn(estimator, X, method="predict"):
     return pred.ravel()
 
 
+def _compute_ale_1d_curve(
+    estimator,
+    X_sample,
+    feature_idx,
+    feature_type,
+    grid_values,
+    method="predict",
+):
+    """Internal closure to compute the ALE 1D curve on a fixed grid.
+
+    Parameters
+    ----------
+    estimator : fitted sklearn-compatible estimator
+        Must expose `predict`, `predict_proba`, or `decision_function`.
+    X_sample : ndarray of shape (n_samples, n_features)
+        Training (or evaluation) dataset used to compute the ALE curve on the
+        given grid.
+    feature_idx : int
+        Column index of the feature of interest.
+    feature_type : string among "continuous", or "categorical"
+        Type of the numeric feature.
+    grid_values: ndarray
+        The grid used to compute the ALE curve.
+    method : str, default="predict"
+        The method to use for the prediction. Supported methods are "predict",
+        "predict_proba" or "decision_function".
+    """
+    X_j_sample = X_sample[:, feature_idx]
+    X_low = X_sample.copy()
+    X_high = X_sample.copy()
+
+    if feature_type == "continuous":
+        n_bins = len(grid_values) - 1
+        bin_idx = _bin_indices(X_j_sample, grid_values)
+
+        # For each sample, evaluate the model at the lower and upper edge of its bin
+        X_low[:, feature_idx] = grid_values[bin_idx]
+        X_high[:, feature_idx] = grid_values[bin_idx + 1]
+
+        local_effects = _predict_fn(estimator, X_high, method) - _predict_fn(
+            estimator, X_low, method
+        )  # shape (n_samples,)
+
+        combined_idx = bin_idx
+        combined_effects = local_effects
+        min_weight_bin = 0
+
+    else:
+        n_bins = len(grid_values)
+        value_idx = np.digitize(X_j_sample, grid_values) - 1
+
+        # For each sample, evaluate the model at the lower and upper edge of its bin
+        mask_low = X_j_sample != grid_values[0]
+        mask_high = X_j_sample != grid_values[-1]
+        X_low[mask_low, feature_idx] = grid_values[value_idx[mask_low] - 1]
+        X_high[mask_high, feature_idx] = grid_values[value_idx[mask_high] + 1]
+
+        local_effects_low = _predict_fn(
+            estimator, X_sample[mask_low], method
+        ) - _predict_fn(estimator, X_low[mask_low], method)
+        local_effects_high = _predict_fn(
+            estimator, X_high[mask_high], method
+        ) - _predict_fn(estimator, X_sample[mask_high], method)
+
+        # Average local effects within each bin
+        combined_idx = np.concatenate(
+            [value_idx[mask_low], value_idx[mask_high] + 1]
+        )
+        combined_effects = np.concatenate(
+            [local_effects_low, local_effects_high]
+        )
+        min_weight_bin = 1
+
+    # Average local effects within each bin
+    bin_counts = np.bincount(combined_idx, minlength=n_bins).astype(float)
+    bin_sums = np.bincount(
+        combined_idx, weights=combined_effects, minlength=n_bins
+    )
+
+    mean_effects = np.zeros(n_bins, dtype=float)
+    non_zero = bin_counts > 0
+    mean_effects[non_zero] = bin_sums[non_zero] / bin_counts[non_zero]
+
+    # Cumulative sum: uncentered ALE evaluated for each bin edge
+    if feature_type == "continuous":
+        ale_curve = np.array([0, *np.cumsum(mean_effects)])
+    else:
+        ale_curve = np.cumsum(mean_effects)
+
+    # Center: subtract the sample-weighted mean
+    ale_centers = (ale_curve[1:] + ale_curve[:-1]) / 2
+    ale_curve -= (
+        np.sum(ale_centers * bin_counts[min_weight_bin:]) / bin_counts.sum()
+    )
+
+    return ale_curve
+
+
 def compute_ale_1d(
     estimator,
     X,
@@ -117,11 +215,11 @@ def compute_ale_1d(
     percentiles : tuple of float, default=(5, 95)
         The lower and upper percentile used to create the extreme values for the grid.
         Must be in [0, 100].
-    confidence_level : float or None, default=0.95
+    confidence_level : float, default=0.95
         The confidence level used to compute the confidence intervals (e.g., 0.95 for 95%).
-        If None, confidence intervals are not computed.
+        If set to 0, confidence intervals are not computed. Must be in [0, 1[.
     n_bootstraps : int, default=20
-        Number of bootstrap samples to generate if `confidence_level` is not None.
+        Number of bootstrap samples to generate if `confidence_level` is not 0.
     n_jobs : int, default=1
         Number of jobs to run in parallel during bootstrapping. `-1` means using all processors.
     random_state : int or None, default=None
@@ -136,7 +234,7 @@ def compute_ale_1d(
         and the unique values of the feature otherwise).
     ale_err : ndarray of shape (n_quantiles,) or None
         The margin of error for each quantile boundary at the specified confidence level.
-        Returns `None` if `confidence_level` is None.
+        Returns `None` if `confidence_level` is 0.
     """
     X = np.asarray(X)
     X_j = X[:, feature_idx]
@@ -189,97 +287,36 @@ def compute_ale_1d(
             "'feature_type' must be a string among 'continuous' and 'categorical'."
         )
 
-    def _compute_ale_curve(X_sample):
-        """Internal closure to compute the ALE curve on a fixed grid."""
-        X_j_sample = X_sample[:, feature_idx]
-        X_low = X_sample.copy()
-        X_high = X_sample.copy()
-
-        if feature_type == "continuous":
-            bin_idx = _bin_indices(X_j_sample, grid_values)
-
-            # For each sample, evaluate the model at the lower and upper edge of its bin
-            X_low[:, feature_idx] = grid_values[bin_idx]
-            X_high[:, feature_idx] = grid_values[bin_idx + 1]
-
-            local_effects = _predict_fn(
-                estimator, X_high, method
-            ) - _predict_fn(estimator, X_low, method)  # shape (n_samples,)
-
-            combined_idx = bin_idx
-            combined_effects = local_effects
-            min_weight_bin = 0
-
-        else:
-            value_idx = np.digitize(X_j_sample, grid_values) - 1
-
-            # For each sample, evaluate the model at the lower and upper edge of its bin
-            mask_low = X_j_sample != grid_values[0]
-            mask_high = X_j_sample != grid_values[-1]
-            X_low[mask_low, feature_idx] = grid_values[value_idx[mask_low] - 1]
-            X_high[mask_high, feature_idx] = grid_values[
-                value_idx[mask_high] + 1
-            ]
-
-            local_effects_low = _predict_fn(
-                estimator, X_sample[mask_low], method
-            ) - _predict_fn(estimator, X_low[mask_low], method)
-            local_effects_high = _predict_fn(
-                estimator, X_high[mask_high], method
-            ) - _predict_fn(estimator, X_sample[mask_high], method)
-
-            # Average local effects within each bin
-            combined_idx = np.concatenate(
-                [value_idx[mask_low], value_idx[mask_high] + 1]
-            )
-            combined_effects = np.concatenate(
-                [local_effects_low, local_effects_high]
-            )
-            min_weight_bin = 1
-
-        # Average local effects within each bin
-        bin_counts = np.bincount(combined_idx, minlength=n_bins).astype(float)
-        bin_sums = np.bincount(
-            combined_idx, weights=combined_effects, minlength=n_bins
-        )
-
-        mean_effects = np.zeros(n_bins, dtype=float)
-        non_zero = bin_counts > 0
-        mean_effects[non_zero] = bin_sums[non_zero] / bin_counts[non_zero]
-
-        # Cumulative sum: uncentered ALE evaluated for each bin edge
-        if feature_type == "continuous":
-            ale_curve = np.array([0, *np.cumsum(mean_effects)])
-        else:
-            ale_curve = np.cumsum(mean_effects)
-
-        # Center: subtract the sample-weighted mean
-        ale_centers = (ale_curve[1:] + ale_curve[:-1]) / 2
-        ale_curve -= (
-            np.sum(ale_centers * bin_counts[min_weight_bin:])
-            / bin_counts.sum()
-        )
-
-        return ale_curve
-
     # Base calculation
-    ale = _compute_ale_curve(X_bootstrap)
+    ale = _compute_ale_1d_curve(
+        estimator,
+        X_bootstrap,
+        feature_idx=feature_idx,
+        feature_type=feature_type,
+        grid_values=grid_values,
+        method=method,
+    )
     ale_err = None
 
     # Confidence interval
-    if confidence_level is not None:
+    if confidence_level != 0:
         if n_bootstraps < 1:
             raise ValueError("'n_bootstrap' must be strictly greater than 0.")
 
         rng = check_random_state(random_state)
 
         bootstrap_curves = Parallel(n_jobs=n_jobs)(
-            delayed(_compute_ale_curve)(
+            delayed(_compute_ale_1d_curve)(
+                estimator,
                 X_bootstrap[
                     rng.choice(
                         len(X_bootstrap), size=len(X_bootstrap), replace=True
                     )
-                ]
+                ],
+                feature_idx=feature_idx,
+                feature_type=feature_type,
+                grid_values=grid_values,
+                method=method,
             )
             for _ in range(n_bootstraps)
         )
@@ -593,11 +630,12 @@ class ALE:
         percentiles : tuple of float, default=(5, 95)
             The lower and upper percentile used to create the extreme values for the grid.
             Must be in [0, 100].
-        confidence_level : float or None, default=0.95
+        confidence_level : float, default=0.95
             The confidence level used to compute the confidence intervals (e.g., 0.95 for 95%)
-            for the 1D ALE curve. If None, confidence intervals are not computed.
+            for the 1D ALE curve. If set to 0, confidence intervals are not computed.
+            Must be in [0, 1[.
         n_bootstraps : int, default=20
-            Number of bootstrap samples to generate if `confidence_level` is not None.
+            Number of bootstrap samples to generate if `confidence_level` is not 0.
         n_jobs : int, default=1
             Number of jobs to run in parallel during bootstrapping. `-1` means using all processors.
         random_state : int or None, default=None

--- a/src/hidimstat/visualization/accumulated_local_effects.py
+++ b/src/hidimstat/visualization/accumulated_local_effects.py
@@ -78,7 +78,7 @@ def compute_ale_1d(
     confidence_interval=True,
     confidence_level=0.95,
     n_bootstraps=20,
-    n_jobs=-1
+    n_jobs=-1,
 ):
     """Compute the 1D Accumulated Local Effect for a single numerical feature.
 
@@ -217,7 +217,9 @@ def compute_ale_1d(
             mask_low = x_sample != grid_values[0]
             mask_high = x_sample != grid_values[-1]
             X_low[mask_low, feature_idx] = grid_values[value_idx[mask_low] - 1]
-            X_high[mask_high, feature_idx] = grid_values[value_idx[mask_high] + 1]
+            X_high[mask_high, feature_idx] = grid_values[
+                value_idx[mask_high] + 1
+            ]
 
             local_effects_low = _predict_fn(
                 estimator, X_sample[mask_low], method
@@ -253,7 +255,10 @@ def compute_ale_1d(
 
         # Center: subtract the sample-weighted mean
         ale_centers = (ale_curve[1:] + ale_curve[:-1]) / 2
-        ale_curve -= np.sum(ale_centers * bin_counts[min_weight_bin:]) / bin_counts.sum()
+        ale_curve -= (
+            np.sum(ale_centers * bin_counts[min_weight_bin:])
+            / bin_counts.sum()
+        )
 
         return ale_curve
 

--- a/src/hidimstat/visualization/accumulated_local_effects.py
+++ b/src/hidimstat/visualization/accumulated_local_effects.py
@@ -199,9 +199,9 @@ def compute_ale_1d(
             X_low[:, feature_idx] = grid_values[bin_idx]
             X_high[:, feature_idx] = grid_values[bin_idx + 1]
 
-            local_effects = _predict_fn(estimator, X_high, method) - _predict_fn(
-                estimator, X_low, method
-            )  # shape (n_samples,)
+            local_effects = _predict_fn(
+                estimator, X_high, method
+            ) - _predict_fn(estimator, X_low, method)  # shape (n_samples,)
 
             combined_idx = bin_idx
             combined_effects = local_effects

--- a/src/hidimstat/visualization/accumulated_local_effects.py
+++ b/src/hidimstat/visualization/accumulated_local_effects.py
@@ -13,6 +13,7 @@ from hidimstat._utils.grid import (
     _build_quantile_grid_1d,
     _build_quantile_grid_2d,
 )
+from hidimstat._utils.utils import check_random_state
 from hidimstat.samplers.conditional_sampling import _check_data_type
 
 
@@ -78,7 +79,8 @@ def compute_ale_1d(
     confidence_interval=True,
     confidence_level=0.95,
     n_bootstraps=20,
-    n_jobs=-1,
+    n_jobs=1,
+    random_state=None,
 ):
     """Compute the 1D Accumulated Local Effect for a single numerical feature.
 
@@ -122,8 +124,10 @@ def compute_ale_1d(
         The confidence level used to compute the confidence intervals (e.g., 0.95 for 95%).
     n_bootstraps : int, default=20
         Number of bootstrap samples to generate if `confidence_interval` is True.
-    n_jobs : int, default=-1
+    n_jobs : int, default=1
         Number of jobs to run in parallel during bootstrapping. `-1` means using all processors.
+    random_state : int or None, default=None
+        Seed for reproducible bootstraps.
 
     Returns
     -------
@@ -137,12 +141,12 @@ def compute_ale_1d(
         Returns `None` if `confidence_interval` is False.
     """
     X = np.asarray(X)
-    x = X[:, feature_idx]
+    X_j = X[:, feature_idx]
 
     if feature_type == "continuous":
         # Grid defined by quantiles
         grid_values = _build_quantile_grid_1d(
-            x, grid_resolution=grid_resolution, percentiles=percentiles
+            X_j, grid_resolution=grid_resolution, percentiles=percentiles
         )
         n_bins = len(grid_values) - 1
 
@@ -165,14 +169,14 @@ def compute_ale_1d(
                 "in [0, 100] in increasing order"
             )
 
-        low_bnd = np.percentile(x, percentiles[0])
-        high_bnd = np.percentile(x, percentiles[1])
+        low_bnd = np.percentile(X_j, percentiles[0])
+        high_bnd = np.percentile(X_j, percentiles[1])
 
-        valid_mask = (x >= low_bnd) & (x <= high_bnd)
+        valid_mask = (X_j >= low_bnd) & (X_j <= high_bnd)
         X_filtered = X[valid_mask]
-        x_filtered = x[valid_mask]
+        X_j_filtered = X_j[valid_mask]
 
-        grid_values = np.unique(x_filtered)
+        grid_values = np.unique(X_j_filtered)
         n_bins = len(grid_values)
 
         if n_bins < 2:
@@ -190,8 +194,8 @@ def compute_ale_1d(
     def _compute_ale_curve(X_sample):
         """Internal closure to compute the ALE curve on a fixed grid."""
         if feature_type == "continuous":
-            x_sample = X_sample[:, feature_idx]
-            bin_idx = _bin_indices(x_sample, grid_values)
+            X_j_sample = X_sample[:, feature_idx]
+            bin_idx = _bin_indices(X_j_sample, grid_values)
 
             # For each sample, evaluate the model at the lower and upper edge of its bin
             X_low = X_sample.copy()
@@ -208,14 +212,14 @@ def compute_ale_1d(
             min_weight_bin = 0
 
         else:
-            x_sample = X_sample[:, feature_idx]
-            value_idx = np.digitize(x_sample, grid_values) - 1
+            X_j_sample = X_sample[:, feature_idx]
+            value_idx = np.digitize(X_j_sample, grid_values) - 1
 
             # For each sample, evaluate the model at the lower and upper edge of its bin
             X_low = X_sample.copy()
             X_high = X_sample.copy()
-            mask_low = x_sample != grid_values[0]
-            mask_high = x_sample != grid_values[-1]
+            mask_low = X_j_sample != grid_values[0]
+            mask_high = X_j_sample != grid_values[-1]
             X_low[mask_low, feature_idx] = grid_values[value_idx[mask_low] - 1]
             X_high[mask_high, feature_idx] = grid_values[
                 value_idx[mask_high] + 1
@@ -271,14 +275,17 @@ def compute_ale_1d(
         if n_bootstraps < 1:
             raise ValueError("'n_bootstrap' must be strictly greater than 0.")
 
-        def _bootstrap():
-            bootstrap_indices = np.random.default_rng().choice(
-                len(X_bootstrap), size=len(X_bootstrap), replace=True
-            )
-            return _compute_ale_curve(X_bootstrap[bootstrap_indices])
+        rng = check_random_state(random_state)
 
         bootstrap_curves = Parallel(n_jobs=n_jobs)(
-            delayed(_bootstrap)() for _ in range(n_bootstraps)
+            delayed(_compute_ale_curve)(
+                X_bootstrap[
+                    rng.choice(
+                        len(X_bootstrap), size=len(X_bootstrap), replace=True
+                    )
+                ]
+            )
+            for _ in range(n_bootstraps)
         )
         bootstrap_curves = np.array(bootstrap_curves)
 
@@ -349,10 +356,10 @@ def compute_ale_2d(
 
     X = np.asarray(X)
     idx_i, idx_j = feature_indices
-    x_i, x_j = X[:, idx_i], X[:, idx_j]
+    X_i, X_j = X[:, idx_i], X[:, idx_j]
 
     quantiles_i, quantiles_j = _build_quantile_grid_2d(
-        x_i, x_j, grid_resolution=grid_resolution, percentiles=percentiles
+        X_i, X_j, grid_resolution=grid_resolution, percentiles=percentiles
     )
 
     n_bins_i = len(quantiles_i) - 1
@@ -367,8 +374,8 @@ def compute_ale_2d(
             f"Feature {idx_j} has fewer than 2 unique quantile edges. Increase grid_resolution or check your data."
         )
 
-    bin_idx_i = _bin_indices(x_i, quantiles_i)
-    bin_idx_j = _bin_indices(x_j, quantiles_j)
+    bin_idx_i = _bin_indices(X_i, quantiles_i)
+    bin_idx_j = _bin_indices(X_j, quantiles_j)
     bin_idx = [bin_idx_i, bin_idx_j]
 
     # Second-order finite differences: evaluate at the four corners of each 2D bin
@@ -553,7 +560,8 @@ class ALE:
         confidence_interval=True,
         confidence_level=0.95,
         n_bootstraps=20,
-        n_jobs=-1,
+        n_jobs=1,
+        random_state=None,
         cmap="viridis",
         **kwargs,
     ):
@@ -596,8 +604,10 @@ class ALE:
             The confidence level used to compute the confidence intervals (e.g., 0.95 for 95%).
         n_bootstraps : int, default=20
             Number of bootstrap samples to generate if `confidence_interval` is True.
-        n_jobs : int, default=-1
+        n_jobs : int, default=1
             Number of jobs to run in parallel during bootstrapping. `-1` means using all processors.
+        random_state : int or None, default=None
+            Seed for reproducible bootstraps.
         cmap : str, default="viridis"
             Matplotlib colormap used for the 2D mesh plot.
         **kwargs
@@ -643,6 +653,7 @@ class ALE:
                     confidence_level=confidence_level,
                     n_bootstraps=n_bootstraps,
                     n_jobs=n_jobs,
+                    random_state=random_state,
                 )
                 result = {
                     "ale": ale,

--- a/src/hidimstat/visualization/accumulated_local_effects.py
+++ b/src/hidimstat/visualization/accumulated_local_effects.py
@@ -76,7 +76,6 @@ def compute_ale_1d(
     method="predict",
     grid_resolution="auto",
     percentiles=(5, 95),
-    confidence_interval=True,
     confidence_level=0.95,
     n_bootstraps=20,
     n_jobs=1,
@@ -118,12 +117,11 @@ def compute_ale_1d(
     percentiles : tuple of float, default=(5, 95)
         The lower and upper percentile used to create the extreme values for the grid.
         Must be in [0, 100].
-    confidence_interval : bool, default=True
-        Whether to compute the confidence intervals of the ALE curve.
-    confidence_level : float, default=0.95
+    confidence_level : float or None, default=0.95
         The confidence level used to compute the confidence intervals (e.g., 0.95 for 95%).
+        If None, confidence intervals are not computed.
     n_bootstraps : int, default=20
-        Number of bootstrap samples to generate if `confidence_interval` is True.
+        Number of bootstrap samples to generate if `confidence_level` is not None.
     n_jobs : int, default=1
         Number of jobs to run in parallel during bootstrapping. `-1` means using all processors.
     random_state : int or None, default=None
@@ -138,7 +136,7 @@ def compute_ale_1d(
         and the unique values of the feature otherwise).
     ale_err : ndarray of shape (n_quantiles,) or None
         The margin of error for each quantile boundary at the specified confidence level.
-        Returns `None` if `confidence_interval` is False.
+        Returns `None` if `confidence_level` is None.
     """
     X = np.asarray(X)
     X_j = X[:, feature_idx]
@@ -269,7 +267,7 @@ def compute_ale_1d(
     ale_err = None
 
     # Confidence interval
-    if confidence_interval:
+    if confidence_level is not None:
         if n_bootstraps < 1:
             raise ValueError("'n_bootstrap' must be strictly greater than 0.")
 
@@ -555,7 +553,6 @@ class ALE:
         method="predict",
         grid_resolution="auto",
         percentiles=(5, 95),
-        confidence_interval=True,
         confidence_level=0.95,
         n_bootstraps=20,
         n_jobs=1,
@@ -596,12 +593,11 @@ class ALE:
         percentiles : tuple of float, default=(5, 95)
             The lower and upper percentile used to create the extreme values for the grid.
             Must be in [0, 100].
-        confidence_interval : bool, default=True
-            Whether to compute and display confidence intervals around the 1D ALE curve.
-        confidence_level : float, default=0.95
-            The confidence level used to compute the confidence intervals (e.g., 0.95 for 95%).
+        confidence_level : float or None, default=0.95
+            The confidence level used to compute the confidence intervals (e.g., 0.95 for 95%)
+            for the 1D ALE curve. If None, confidence intervals are not computed.
         n_bootstraps : int, default=20
-            Number of bootstrap samples to generate if `confidence_interval` is True.
+            Number of bootstrap samples to generate if `confidence_level` is not None.
         n_jobs : int, default=1
             Number of jobs to run in parallel during bootstrapping. `-1` means using all processors.
         random_state : int or None, default=None
@@ -647,7 +643,6 @@ class ALE:
                     feature_type=feature_type,
                     grid_resolution=grid_resolution,
                     percentiles=percentiles,
-                    confidence_interval=confidence_interval,
                     confidence_level=confidence_level,
                     n_bootstraps=n_bootstraps,
                     n_jobs=n_jobs,

--- a/test/visualization/test_accumulated_local_effects.py
+++ b/test/visualization/test_accumulated_local_effects.py
@@ -190,7 +190,7 @@ def test_compute_ale_1d_continuous(ale_test_data):
     assert len(grid_values) <= grid_resolution + 1
 
     # With confidence interval
-    ale_ci, grid_values_ci, ale_err_ci = compute_ale_1d(
+    _, grid_values_ci, ale_err_ci = compute_ale_1d(
         model,
         X,
         feature_idx=important_features[0],
@@ -199,23 +199,8 @@ def test_compute_ale_1d_continuous(ale_test_data):
         confidence_interval=True,
         confidence_level=0.95,
     )
-    assert isinstance(ale_ci, np.ndarray)
-    assert isinstance(grid_values_ci, np.ndarray)
     assert isinstance(ale_err_ci, np.ndarray)
-    assert len(ale_ci) == len(grid_values_ci)
-    assert len(grid_values_ci) <= grid_resolution + 1
     assert len(ale_err_ci) == len(grid_values_ci)
-
-    # To test _bootstrap()
-    with parallel_backend("threading"):
-        result_bootstrap = compute_ale_1d(
-            model,
-            X,
-            feature_idx=important_features[0],
-            feature_type="continuous",
-            confidence_interval=True,
-            n_bootstraps=2,
-        )
 
 
 def test_compute_ale_1d_continuous_error(ale_test_data):

--- a/test/visualization/test_accumulated_local_effects.py
+++ b/test/visualization/test_accumulated_local_effects.py
@@ -296,7 +296,12 @@ def test_compute_ale_1d_discrete(ale_test_data):
     # To test _bootstrap()
     with parallel_backend("threading"):
         result_bootstrap = compute_ale_1d(
-            model, X, feature_idx=0, feature_type="categorical", confidence_interval=True, n_bootstraps=2
+            model,
+            X,
+            feature_idx=0,
+            feature_type="categorical",
+            confidence_interval=True,
+            n_bootstraps=2,
         )
 
 
@@ -309,10 +314,17 @@ def test_compute_ale_1d_discrete_error(ale_test_data):
     X_const[:, 0] = 7
 
     with pytest.raises(ValueError, match="has fewer than 2 unique values"):
-        compute_ale_1d(model, X_const, feature_idx=0, feature_type="categorical")
+        compute_ale_1d(
+            model, X_const, feature_idx=0, feature_type="categorical"
+        )
     with pytest.raises(ValueError, match="must be strictly greater than"):
         compute_ale_1d(
-            model, X, feature_idx=0, feature_type="categorical", confidence_interval=True, n_bootstraps=0
+            model,
+            X,
+            feature_idx=0,
+            feature_type="categorical",
+            confidence_interval=True,
+            n_bootstraps=0,
         )
 
     with pytest.raises(

--- a/test/visualization/test_accumulated_local_effects.py
+++ b/test/visualization/test_accumulated_local_effects.py
@@ -2,6 +2,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from joblib import parallel_backend
 from sklearn.base import BaseEstimator
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.exceptions import NotFittedError
@@ -205,11 +206,26 @@ def test_compute_ale_1d_continuous(ale_test_data):
     assert len(grid_values_ci) <= grid_resolution + 1
     assert len(ale_err_ci) == len(grid_values_ci)
 
+    # To test _bootstrap()
+    with parallel_backend("threading"):
+        result_bootstrap = compute_ale_1d(
+            model,
+            X,
+            feature_idx=important_features[0],
+            feature_type="continuous",
+            confidence_interval=True,
+            n_bootstraps=2,
+        )
+
 
 def test_compute_ale_1d_continuous_error(ale_test_data):
     """Check the raised error if the continuous feature does not have enough unique quantiles."""
     data = ale_test_data["continuous"]
-    X, model = data["X"], data["model"]
+    X, model, important_features = (
+        data["X"],
+        data["model"],
+        data["important_features"],
+    )
 
     X_const = X.copy()
     X_const[:, 0] = 7
@@ -234,6 +250,15 @@ def test_compute_ale_1d_continuous_error(ale_test_data):
             feature_idx=0,
             feature_type="invalid_feature_type",
             grid_resolution=10,
+        )
+    with pytest.raises(ValueError, match="must be strictly greater than"):
+        compute_ale_1d(
+            model,
+            X,
+            feature_idx=important_features[0],
+            feature_type="continuous",
+            confidence_interval=True,
+            n_bootstraps=0,
         )
 
 
@@ -268,6 +293,12 @@ def test_compute_ale_1d_discrete(ale_test_data):
     assert isinstance(ale_err_ci, np.ndarray)
     assert len(ale_err_ci) == len(grid_values_ci)
 
+    # To test _bootstrap()
+    with parallel_backend("threading"):
+        result_bootstrap = compute_ale_1d(
+            model, X, feature_idx=0, feature_type="categorical", confidence_interval=True, n_bootstraps=2
+        )
+
 
 def test_compute_ale_1d_discrete_error(ale_test_data):
     """Check the raised error if the discrete feature does not have enough unique values."""
@@ -278,8 +309,10 @@ def test_compute_ale_1d_discrete_error(ale_test_data):
     X_const[:, 0] = 7
 
     with pytest.raises(ValueError, match="has fewer than 2 unique values"):
+        compute_ale_1d(model, X_const, feature_idx=0, feature_type="categorical")
+    with pytest.raises(ValueError, match="must be strictly greater than"):
         compute_ale_1d(
-            model, X_const, feature_idx=0, feature_type="categorical"
+            model, X, feature_idx=0, feature_type="categorical", confidence_interval=True, n_bootstraps=0
         )
 
     with pytest.raises(

--- a/test/visualization/test_accumulated_local_effects.py
+++ b/test/visualization/test_accumulated_local_effects.py
@@ -181,7 +181,7 @@ def test_compute_ale_1d_continuous(ale_test_data):
         feature_idx=important_features[0],
         feature_type="continuous",
         grid_resolution=grid_resolution,
-        confidence_interval=False,
+        confidence_level=0,
     )
     assert isinstance(ale, np.ndarray)
     assert isinstance(grid_values, np.ndarray)
@@ -196,7 +196,6 @@ def test_compute_ale_1d_continuous(ale_test_data):
         feature_idx=important_features[0],
         feature_type="continuous",
         grid_resolution=grid_resolution,
-        confidence_interval=True,
         confidence_level=0.95,
     )
     assert isinstance(ale_err_ci, np.ndarray)
@@ -242,7 +241,7 @@ def test_compute_ale_1d_continuous_error(ale_test_data):
             X,
             feature_idx=important_features[0],
             feature_type="continuous",
-            confidence_interval=True,
+            confidence_level=0.95,
             n_bootstraps=0,
         )
 
@@ -258,7 +257,7 @@ def test_compute_ale_1d_discrete(ale_test_data):
         X,
         feature_idx=0,
         feature_type="categorical",
-        confidence_interval=False,
+        confidence_level=0,
     )
     assert isinstance(ale, np.ndarray)
     assert isinstance(grid_values, np.ndarray)
@@ -272,8 +271,7 @@ def test_compute_ale_1d_discrete(ale_test_data):
         X,
         feature_idx=0,
         feature_type="categorical",
-        confidence_interval=True,
-        confidence_level=0.90,
+        confidence_level=0.95,
     )
     assert isinstance(ale_err_ci, np.ndarray)
     assert len(ale_err_ci) == len(grid_values_ci)
@@ -285,7 +283,7 @@ def test_compute_ale_1d_discrete(ale_test_data):
             X,
             feature_idx=0,
             feature_type="categorical",
-            confidence_interval=True,
+            confidence_level=0.95,
             n_bootstraps=2,
         )
 
@@ -308,7 +306,7 @@ def test_compute_ale_1d_discrete_error(ale_test_data):
             X,
             feature_idx=0,
             feature_type="categorical",
-            confidence_interval=True,
+            confidence_level=0.95,
             n_bootstraps=0,
         )
 
@@ -504,13 +502,13 @@ def test_ale_plot_smoke(ale_test_data):
         data_continuous["X"],
         features=data_continuous["important_features"][0],
         grid_resolution=10,
-        confidence_interval=True,
+        confidence_level=0.95,
     )
     assert ax_1d_continuous is not None
     plt.close("all")
 
     ax_1d_discrete = ale_discrete.plot(
-        data_discrete["X"], features=0, confidence_interval=True
+        data_discrete["X"], features=0, confidence_level=0.95
     )
     assert ax_1d_discrete is not None
     plt.close("all")


### PR DESCRIPTION
Related to PR #701 

Instead of calculating the standard deviation for each bin edge based on a single ALE curve, we calculate multiple curves to obtain more reliable confidence intervals.
