### PR TITLE
[DOC] Missing classes from API autosummary

### DIFF
--- a/docs/src/api.rst
+++ b/docs/src/api.rst
@@ -25,6 +25,8 @@ Feature Importance Classes
    :toctree: ./generated/api/class/
    :template: class.rst
 
+   LOCI
+   LOCICV
    LOCO
    LOCOCV
    CFI
@@ -33,6 +35,7 @@ Feature Importance Classes
    EnCluDL
    PFI
    PFICV
+   SAGE
    D0CRT
    ModelXKnockoff
    DesparsifiedLasso
@@ -48,6 +51,7 @@ Feature Importance functions
    d0crt_importance
    desparsified_lasso_importance
    model_x_knockoff_importance
+   loci_importance
    loco_importance
    pfi_importance
 

--- a/src/hidimstat/shapley_additive_global_importance.py
+++ b/src/hidimstat/shapley_additive_global_importance.py
@@ -83,8 +83,8 @@ def _sample_feature_subsets(n_features, j, n_subsets, random_state=None):
 
 class SAGE(BaseVariableImportance, GroupVariableImportanceMixin):
     """
-    Shaple Additive Global Importance (SAGE) values for feature importance,
-    from :footcite:t:`Covert2020`.
+    Shapley Additive Global Importance (SAGE) values for feature importance.
+    Read more on SAGE here :footcite:t:`Covert2020`.
 
     Parameters
     ----------


### PR DESCRIPTION
`SAGE`, `LOCI`, `LOCICV`, and method `loci_importance` were missing from the API auto-generated summary which made the sphinx doc generation fail if any reference to one of them was made.