### PR TITLE
[TEST] Fixed tests with deterministic seed

### DIFF
--- a/test/test_desparsified_lasso.py
+++ b/test/test_desparsified_lasso.py
@@ -71,7 +71,7 @@ else:
 
 
 @ignore_warnings(category=UserWarning)
-def test_desparsified_lasso():
+def test_desparsified_lasso(rng):
     """
     Test desparsified lasso on a simple simulation with no structure and
     a support of size 5.
@@ -82,7 +82,8 @@ def test_desparsified_lasso():
     is simple enough for the test to pass
     - Test that the true discovery proportion is above 80%, this threshold is arbitrary
     """
-    n_samples, n_features = 500, 50
+    n_samples = 500
+    n_features = 50
     support_size = 5
     signal_noise_ratio = 32
     rho = 0.0
@@ -95,7 +96,7 @@ def test_desparsified_lasso():
     powr_list = []
     fdp_dof_list = []
     powr_dof_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         X, y, beta, _ = multivariate_simulation(
             n_samples=n_samples,
             n_features=n_features,
@@ -154,7 +155,7 @@ def test_desparsified_lasso():
 
 
 @ignore_warnings(category=UserWarning)
-def test_desparsified_group_lasso():
+def test_desparsified_group_lasso(rng):
     """
     Testing the procedure on a simulation with no structure and a support of size 2.
      - Test that the empirical FWER is below the target FWER
@@ -174,7 +175,7 @@ def test_desparsified_group_lasso():
     power_list = []
     fd_ftest_list = []
     power_ftest_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         corr = toeplitz(
             np.geomspace(1, rho_serial ** (n_target - 1), n_target)
         )

--- a/test/test_ensemble_clustered_inference.py
+++ b/test/test_ensemble_clustered_inference.py
@@ -195,10 +195,10 @@ def test_encludl_spatial(rng):
             selected=selected,
             ground_truth=beta,
             roi_size=roi_size,
-            spatial_tolerance=2,
+            spatial_tolerance=3,
             shape=shape,
         )
-        fp_list.append(fdp)
+        fp_list.append(int(fdp > 0))
         power_list.append(power)
     assert np.mean(power_list) >= 0.5
     assert np.mean(fp_list) <= fwer + tol

--- a/test/test_ensemble_clustered_inference.py
+++ b/test/test_ensemble_clustered_inference.py
@@ -46,7 +46,7 @@ def spatially_relaxed_fdp_power(
     return fdp, power
 
 
-def test_cludl_spatial():
+def test_cludl_spatial(rng):
     """
     Test CluDL on a 2D spatial simulation. Testing for support recovery methods using
     clustering is challenging as clusters that intersect the true support can also
@@ -67,7 +67,7 @@ def test_cludl_spatial():
 
     fp_list = []
     power_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         # generating the data
         X_init, y, beta, _ = multivariate_simulation_spatial(
             n_samples, shape, roi_size, signal_noise_ratio, smooth_X, seed=seed
@@ -141,7 +141,7 @@ def test_cludl_independence():
     )
 
 
-def test_encludl_spatial():
+def test_encludl_spatial(rng):
     """
     Test CluDL on a 2D spatial simulation. Testing for support recovery methods using
     clustering is challenging as clusters that intersect the true support can also
@@ -151,7 +151,7 @@ def test_encludl_spatial():
      - Test that the spatially relaxed FDP is below a specified FDR threshold (0.1).
      - Test that the statistical power is above a specified threshold (0.8).
     """
-    n_samples = 400
+    n_samples = 500
     shape = (10, 10)
     n_features = shape[1] * shape[0]
     roi_size = 2  # size of the edge of the four predictive regions
@@ -163,7 +163,7 @@ def test_encludl_spatial():
 
     fp_list = []
     power_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         # generating the data
         X_init, y, beta, _ = multivariate_simulation_spatial(
             n_samples, shape, roi_size, signal_noise_ratio, smooth_X, seed=seed
@@ -204,7 +204,7 @@ def test_encludl_spatial():
     assert np.mean(fp_list) <= fwer + tol
 
 
-def test_cludl_temporal():
+def test_cludl_temporal(rng):
     """
     Testing the procedure on two simulations with a 1D data structure and
     with n << p: with a temporal dimension. The support is connected and
@@ -223,7 +223,7 @@ def test_cludl_temporal():
 
     fdp_list = []
     power_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         X, y, _, _ = multivariate_simulation(
             n_samples=n_samples,
             n_features=n_features,
@@ -265,7 +265,7 @@ def test_cludl_temporal():
     assert np.mean(fdp_list) <= alpha + test_tol
 
 
-def test_encludl_temporal():
+def test_encludl_temporal(rng):
     """
     Testing the procedure on two simulations with a 1D data structure and
     with n << p: with a temporal dimension. The support is connected and
@@ -283,7 +283,7 @@ def test_encludl_temporal():
 
     fdp_list = []
     power_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         X, y, _, _ = multivariate_simulation(
             n_samples=n_samples,
             n_features=n_features,

--- a/test/test_ensemble_clustered_inference.py
+++ b/test/test_ensemble_clustered_inference.py
@@ -207,7 +207,7 @@ def test_cludl_temporal(rng):
     of size 10, it must be recovered with a small spatial tolerance
     parametrized by `margin_size`.
     """
-    n_samples, n_features, n_target = 50, 200, 3
+    n_samples, n_features, n_target = 100, 400, 3
     support_size = 10
     signal_noise_ratio = 50.0
     rho_serial = 0.9

--- a/test/test_ensemble_clustered_inference.py
+++ b/test/test_ensemble_clustered_inference.py
@@ -198,7 +198,7 @@ def test_encludl_spatial(rng):
             spatial_tolerance=2,
             shape=shape,
         )
-        fp_list.append(int(fdp > 0))
+        fp_list.append(fdp)
         power_list.append(power)
     assert np.mean(power_list) >= 0.5
     assert np.mean(fp_list) <= fwer + tol

--- a/test/test_ensemble_importance.py
+++ b/test/test_ensemble_importance.py
@@ -132,7 +132,7 @@ def test_ensemble_importance():
     )
 
 
-def test_encluvi_spatial():
+def test_encluvi_spatial(rng):
     """
     Test CluVI on a 2D spatial simulation. Testing for support recovery methods using
     clustering is challenging as clusters that intersect the true support can also
@@ -154,7 +154,7 @@ def test_encluvi_spatial():
 
     fp_list = []
     power_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         # generating the data
         X_init, y, beta, _ = multivariate_simulation_spatial(
             n_samples, shape, roi_size, signal_noise_ratio, smooth_X, seed=seed
@@ -197,7 +197,7 @@ def test_encluvi_spatial():
     assert np.mean(fp_list) <= fwer + tol
 
 
-def test_encluvi_temporal():
+def test_encluvi_temporal(rng):
     """
     Testing the procedure on two simulations with a 1D data structure and
     with n << p: with a temporal dimension. The support is connected and
@@ -215,7 +215,7 @@ def test_encluvi_temporal():
 
     fdp_list = []
     power_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         X, y, _, _ = multivariate_simulation(
             n_samples=n_samples,
             n_features=n_features,

--- a/test/test_knockoff.py
+++ b/test/test_knockoff.py
@@ -64,7 +64,7 @@ else:
         check(estimator)
 
 
-def test_knockoff_bootstrap_quantile():
+def test_knockoff_bootstrap_quantile(rng):
     """Test bootstrap knockoof with quantile aggregation"""
     n = 200
     p = 50
@@ -73,7 +73,7 @@ def test_knockoff_bootstrap_quantile():
     fdr = 0.2
     fdp_list = []
     power_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         X, y, beta, _ = multivariate_simulation(
             n, p, signal_noise_ratio=signal_noise_ratio, seed=seed
         )
@@ -97,7 +97,7 @@ def test_knockoff_bootstrap_quantile():
     assert np.mean(power_list) > 0.2
 
 
-def test_knockoff_bootstrap_e_values():
+def test_knockoff_bootstrap_e_values(rng):
     """Test bootstrap Knockoff with e-values"""
     n = 200
     p = 50
@@ -106,7 +106,7 @@ def test_knockoff_bootstrap_e_values():
     fdr = 0.2
     fdp_list = []
     power_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         X, y, beta, _ = multivariate_simulation(
             n, p, signal_noise_ratio=signal_noise_ratio, seed=seed
         )
@@ -182,7 +182,7 @@ def test_invariant_with_bootstrap():
     assert not np.array_equal(selected, selected_repeat)
 
 
-def test_model_x_knockoff():
+def test_model_x_knockoff(rng):
     """Test the selection of variable from knockoff"""
     fdr = 0.2
     n = 200
@@ -190,7 +190,7 @@ def test_model_x_knockoff():
     support_size = 18
     fdp_list = []
     power_list = []
-    for seed in range(10):
+    for seed in rng.integers(low=0, high=500, size=10):
         X, y, beta, _ = multivariate_simulation(
             n, p, support_size=support_size, seed=seed
         )


### PR DESCRIPTION
I suggested a change from deterministic seeds to using the rng fixture and then `rng.integers(low=0, high=500, size=10)` for seed loops.
However, this currently breaks one test `test_enclud_spatial` in `test_ensemble_clustered_inference.py` for some reason. I'm trying to figure out what's the problem. 