### PR TITLE
[MAINT] Fixed null condition when checking for draft PR on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,11 @@ jobs:
     needs: [get_information]
     uses: ./.github/workflows/call_test_package.yml
     with:
-      skip_test: ${{ contains(needs.get_information.outputs.COMMIT_MSG, '[skip tests]') || github.event.pull_request.draft }}
+      skip_test: ${{ contains(needs.get_information.outputs.COMMIT_MSG, '[skip tests]') || github.event.pull_request.draft == true}}
 
   tests_minimal:
     name: tests minimal
     needs: [get_information]
     uses: ./.github/workflows/call_test_minimal.yml
     with:
-      skip_test: ${{ contains(needs.get_information.outputs.COMMIT_MSG, '[skip tests]') || github.event.pull_request.draft }}
+      skip_test: ${{ contains(needs.get_information.outputs.COMMIT_MSG, '[skip tests]') || github.event.pull_request.draft == true}}


### PR DESCRIPTION
Fixed a test (check if pull request is draft) that resolved to null instead of boolean in Github Actions when workflow is executed on the `main` branch.