### PR TITLE
[BUG] Fixed section parsing issue

### DIFF
--- a/src/hidimstat/_utils/docstring.py
+++ b/src/hidimstat/_utils/docstring.py
@@ -20,8 +20,12 @@ def _detection_section(lines):
     index_line = 1
     begin_section = index_line
     while len(lines) > index_line:
-        if "-------" in lines[index_line]:
-            sections.append(lines[begin_section : index_line - 2])
+        if lines[index_line].startswith("-"):
+            end_index = index_line - 1
+            # We check whether there is a blank line before the next section
+            if lines[end_index - 1] == "":
+                end_index -= 1
+            sections.append(lines[begin_section:end_index])
             begin_section = index_line - 1
         index_line += 1
     sections.append(lines[begin_section : len(lines)])
@@ -47,7 +51,7 @@ def _parse_docstring(docstring):
     section_texts = _detection_section(lines)
     sections = {"short": section_texts[0]}
     for section_text in section_texts:
-        if len(section_text) <= 1 or "---" not in section_text[1]:
+        if len(section_text) <= 1 or not section_text[1].startswith("-"):
             sections["short"] = section_text
         else:
             sections["".join(section_text[0].split())] = section_text


### PR DESCRIPTION
Replaced hard-coded string check with a `startswith` as suggested in the related issue #770 .
I also added a check for the end index of the section depending on whether there is a blank line before or not for more robustness.