### PR TITLE
[BUG] LOCI now uses marginal probability in binary classif

### DIFF
--- a/src/hidimstat/leave_one_covariate_in.py
+++ b/src/hidimstat/leave_one_covariate_in.py
@@ -103,11 +103,11 @@ class LOCI(BasePerturbation):
         )
         if self.method in ["predict_proba", "decision_function"]:
             values, counts = np.unique(y, return_counts=True)
-            # Binary classification
+            # We take the marginal probability in any case.
+            # Binary classification, shape of y is (n_samples,)
             if len(values) == 2:
-                values, counts = np.unique(y, return_counts=True)
-                self._baseline_mean = values[np.argmax(counts)]
-            # For multiclass classification, we take the marginal probability.
+                self._baseline_mean = counts[1] / y.shape[0]
+            # For multiclass classification, shape of y is (n_samples, n_classes)
             else:
                 self._baseline_mean = counts / y.shape[0]
         elif self.method == "predict":

--- a/test/test_leave_one_covariate_in.py
+++ b/test/test_leave_one_covariate_in.py
@@ -137,6 +137,35 @@ def test_multiclass_loci():
     assert importance_clf[0].mean() > importance_clf[1].mean()
 
 
+@pytest.mark.parametrize("method", ["predict_proba", "decision_function"])
+def test_loci_baseline_mean_classification(method):
+    """For binary classification with methods 'predict_proba' and 'decision_function'
+    check that the baseline mean is equal to the marginal distribution.
+    """
+    important_features = 4
+    n_features = 20
+
+    X, y = make_classification(
+        n_samples=100,
+        n_features=n_features,
+        n_informative=important_features,
+        n_classes=2,
+        weights=[0.3, 0.7],
+        random_state=42,
+        shuffle=False,
+    )
+    estimator = LogisticRegression().fit(X, y)
+    loci = LOCI(estimator=estimator, method=method)
+    loci.fit(X, y)
+
+    values, counts = np.unique(y, return_counts=True)
+    assert list(values) == [0, 1]
+    expected_baseline_mean = counts[1] / y.shape[0]
+
+    assert loci._baseline_mean == pytest.approx(expected_baseline_mean)
+    assert loci._baseline_mean == pytest.approx(np.mean(y))
+
+
 def test_raises_value_error():
     """Test for error when model does not have predict_proba or predict."""
     X, y, _, _ = multivariate_simulation(


### PR DESCRIPTION
I switched to marginal probabilty of the positive class as the baseline for LOCI in binary classification:
```python
if self.method in ["predict_proba", "decision_function"]:
  values, counts = np.unique(y, return_counts=True)
  # We take the marginal probability in any case.
  # Binary classification, shape of y is (n_samples,)
  if len(values) == 2:
      self._baseline_mean = counts[1] / y.shape[0]
  # For multiclass classification, shape of y is (n_samples, n_classes)
  else:
      self._baseline_mean = counts / y.shape[0]
```

I also removed the redundant line.